### PR TITLE
Clear search on pressing enter

### DIFF
--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -117,6 +117,9 @@ class _HomePageState extends State<HomePage> {
                     storageWidget.search(value);
                   },
                   controller: storageWidget.searchController,
+                  onSubmitted: ((value) {
+                    storageWidget.searchController.clear();
+                  }),
                 ),
               ),
             Expanded(


### PR DESCRIPTION
In issue #42, search controller cleared when the user presses enter.