### PR TITLE
REFACTOR: replaced `print` calls with `debugPrint`

### DIFF
--- a/lib/services/notification_services.dart
+++ b/lib/services/notification_services.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
@@ -23,16 +24,16 @@ class NotificationService {
   void sendNotification(DateTime dtb, String task) async {
     DateTime dateTime = DateTime.now();
     tz.initializeTimeZones();
-    print("date and time are:-$dateTime");
-    print("date and time are:-$dtb");
+    debugPrint("date and time are:-$dateTime");
+    debugPrint("date and time are:-$dtb");
 
     final tz.TZDateTime scheduledAt =
         tz.TZDateTime.from(dtb.add(const Duration(minutes: 1)), tz.local);
     final tz.TZDateTime scheduledAt1 = tz.TZDateTime.local(dateTime.year,
         dateTime.month, dateTime.day, dateTime.hour, dateTime.minute);
-    // print("date and time are:-" + dateTime.toString());
-    print("dtb is :-$scheduledAt");
-    print("date and time are scheduled2:-$scheduledAt1");
+    // debugPrint("date and time are:-" + dateTime.toString());
+    debugPrint("dtb is :-$scheduledAt");
+    debugPrint("date and time are scheduled2:-$scheduledAt1");
 
     AndroidNotificationDetails androidNotificationDetails =
         const AndroidNotificationDetails('channelId', 'TaskReminder',
@@ -52,6 +53,6 @@ class NotificationService {
         uiLocalNotificationDateInterpretation:
             UILocalNotificationDateInterpretation.absoluteTime,
         androidAllowWhileIdle: true);
-    print(scheduledAt.day * 100 + scheduledAt.hour * 10 + scheduledAt.minute);
+    debugPrint((scheduledAt.day * 100 + scheduledAt.hour * 10 + scheduledAt.minute).toString());
   }
 }

--- a/lib/widgets/buildTasks.dart
+++ b/lib/widgets/buildTasks.dart
@@ -147,12 +147,12 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                                 dtb.hour * 10 +
                                                 dtb.minute);
 
-                                          print("Task due is $dtb");
-                                          print(widget
-                                              .taskData); // status is in first index
-                                          print(dtb.day * 100 +
+                                          debugPrint("Task due is $dtb");
+                                          debugPrint((widget
+                                              .taskData).toString()); // status is in first index
+                                          debugPrint((dtb.day * 100 +
                                               dtb.hour * 10 +
-                                              dtb.minute);
+                                              dtb.minute).toString());
 
                                           Navigator.of(context).pop();
                                         },
@@ -207,10 +207,10 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                                   dtb.hour * 10 +
                                                   dtb.minute);
 
-                                          print("Task due is$dtb");
-                                          print(dtb.day * 100 +
+                                          debugPrint("Task due is$dtb");
+                                          debugPrint((dtb.day * 100 +
                                               dtb.hour * 10 +
-                                              dtb.minute);
+                                              dtb.minute).toString());
                                           Navigator.of(context).pop();
                                         },
                                         child: const Text('Yes'),

--- a/lib/widgets/taskdetails/status_widget.dart
+++ b/lib/widgets/taskdetails/status_widget.dart
@@ -35,7 +35,7 @@ class StatusWidget extends StatelessWidget {
           ),
         ),
         onTap: () {
-          print(value);
+          debugPrint(value);
           switch (value) {
             case 'pending':
               return callback('completed');


### PR DESCRIPTION
Closes #125 