### PR TITLE
Redisgned FilterDrawer

### DIFF
--- a/lib/drawer/filter_drawer.dart
+++ b/lib/drawer/filter_drawer.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
@@ -27,87 +28,178 @@ class FilterDrawer extends StatelessWidget {
             primary: false,
             key: const PageStorageKey('tags-filter'),
             children: [
-              Card(
+              const Divider(
+                color: Color.fromARGB(0, 48, 46, 46),
+              ),
+              Container(
+                height: 45,
+                alignment: Alignment.center,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                  child: Text(
+                    'Filter',
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: (AppSettings.isDarkMode
+                            ? Colors.white
+                            : Color.fromARGB(255, 48, 46, 46)),
+                        fontSize: 35),
+                  ),
+                ),
+              ),
+              const Divider(
+                color: Color.fromARGB(0, 48, 46, 46),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: AppSettings.isDarkMode
+                      ? Color.fromARGB(255, 48, 46, 46)
+                      : Color.fromARGB(255, 220, 216, 216),
+                ),
                 child: ListTile(
                   title: Text(
                     'filter:${filters.pendingFilter ? 'status : pending' : 'status : archived'}',
+                    style: TextStyle(
+                      fontFamily: GoogleFonts.firaMono().fontFamily,
+                      fontSize: 18,
+                    ),
                   ),
                   onTap: filters.togglePendingFilter,
-                  tileColor: AppSettings.isDarkMode
-                      ? Color.fromARGB(255, 48, 46, 46)
-                      : Color.fromARGB(255, 220, 216, 216),
                   textColor: AppSettings.isDarkMode
                       ? Colors.white
                       : Color.fromARGB(255, 48, 46, 46),
                 ),
               ),
-              const Divider(),
-              ProjectsColumn(
-                filters.projects,
-                filters.projectFilter,
-                filters.toggleProjectFilter,
+              const Divider(
+                color: Color.fromARGB(0, 48, 46, 46),
               ),
-              const Divider(),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                child: TagFiltersWrap(filters.tagFilters),
-              ),
-              const Divider(),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                child: Text(
-                  'Sort By : ',
-                  style: TextStyle(
-                      color: (AppSettings.isDarkMode
-                          ? Colors.white
-                          : Colors.black),
-                      fontStyle: FontStyle.normal,
-                      fontSize: 20),
-                  textAlign: TextAlign.left,
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: AppSettings.isDarkMode
+                      ? Color.fromARGB(255, 48, 46, 46)
+                      : Color.fromARGB(255, 220, 216, 216),
+                ),
+                child: ProjectsColumn(
+                  filters.projects,
+                  filters.projectFilter,
+                  filters.toggleProjectFilter,
                 ),
               ),
-              const Divider(),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 4,
+              const Divider(
+                color: Color.fromARGB(0, 48, 46, 46),
+              ),
+              Container(
+                height: 55,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: AppSettings.isDarkMode
+                      ? Color.fromARGB(255, 48, 46, 46)
+                      : Color.fromARGB(255, 220, 216, 216),
+                ),
+                child: Row(
                   children: [
-                    for (var sort in [
-                      'Created',
-                      'Modified',
-                      'Start Time',
-                      'Due till',
-                      'Priority',
-                      'Project',
-                      'Tags',
-                      'Urgency',
-                    ])
-                      ChoiceChip(
-                        label: (storageWidget.selectedSort.startsWith(sort))
-                            ? Text(
-                                storageWidget.selectedSort,
-                              )
-                            : Text(sort),
-                        selected: false,
-                        onSelected: (_) {
-                          if (storageWidget.selectedSort == '$sort+') {
-                            storageWidget.selectSort('$sort-');
-                          } else {
-                            storageWidget.selectSort('$sort+');
-                          }
-                        },
-                        labelStyle: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? Colors.black
-                                : Colors.white),
-                        backgroundColor: AppSettings.isDarkMode
-                            ? Color.fromARGB(255, 220, 216, 216)
-                            : Color.fromARGB(255, 48, 46, 46),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                      child: Text(
+                        '  Filter Tag By: ',
+                        style: TextStyle(
+                            color: (AppSettings.isDarkMode
+                                ? Colors.white
+                                : Color.fromARGB(255, 48, 46, 46)),
+                            fontFamily: GoogleFonts.firaMono().fontFamily,
+                            fontSize: 18),
+                        //textAlign: TextAlign.right,
                       ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: TagFiltersWrap(filters.tagFilters),
+                    )
                   ],
                 ),
               ),
+              const Divider(
+                color: Color.fromARGB(0, 48, 46, 46),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: AppSettings.isDarkMode
+                      ? Color.fromARGB(255, 48, 46, 46)
+                      : Color.fromARGB(255, 220, 216, 216),
+                ),
+                //height: 30,
+                child: Column(
+                  children: [
+                    const Divider(
+                      color: Color.fromARGB(0, 48, 46, 46),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                      child: Text(
+                        'Sort By',
+                        style: TextStyle(
+                            color: (AppSettings.isDarkMode
+                                ? Colors.white
+                                : Color.fromARGB(255, 48, 46, 46)),
+                            fontFamily: GoogleFonts.firaMono().fontFamily,
+                            fontSize: 18),
+                        //textAlign: TextAlign.right,
+                      ),
+                    ),
+                    const Divider(
+                      color: Color.fromARGB(0, 48, 46, 46),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children: [
+                          for (var sort in [
+                            'Created',
+                            'Modified',
+                            'Start Time',
+                            'Due till',
+                            'Priority',
+                            'Project',
+                            'Tags',
+                            'Urgency',
+                          ])
+                            ChoiceChip(
+                              label:
+                                  (storageWidget.selectedSort.startsWith(sort))
+                                      ? Text(
+                                          storageWidget.selectedSort,
+                                        )
+                                      : Text(sort),
+                              selected: false,
+                              onSelected: (_) {
+                                if (storageWidget.selectedSort == '$sort+') {
+                                  storageWidget.selectSort('$sort-');
+                                } else {
+                                  storageWidget.selectSort('$sort+');
+                                }
+                              },
+                              labelStyle: TextStyle(
+                                  color: AppSettings.isDarkMode
+                                      ? Colors.black
+                                      : Colors.white),
+                              backgroundColor: AppSettings.isDarkMode
+                                  ? Color.fromARGB(255, 220, 216, 216)
+                                  : Color.fromARGB(255, 48, 46, 46),
+                            ),
+                        ],
+                      ),
+                    ),
+                    const Divider(
+                      color: Color.fromARGB(0, 48, 46, 46),
+                    ),
+                  ],
+                ),
+              )
             ],
           ),
         ),

--- a/lib/widgets/project_filter.dart
+++ b/lib/widgets/project_filter.dart
@@ -49,7 +49,9 @@ class ProjectsColumn extends StatelessWidget {
         title: Text(
           'project:$projectFilter',
           style: GoogleFonts.firaMono(
-              color: AppSettings.isDarkMode ? Colors.white : Colors.black),
+            color: AppSettings.isDarkMode ? Colors.white : Colors.black,
+            fontSize: 18,
+          ),
         ),
         backgroundColor: AppSettings.isDarkMode
             ? const Color.fromARGB(255, 48, 46, 46)


### PR DESCRIPTION
closes #132 
- This pr will be giving a new redisgn to the UI of FilterDrawer, which will be closing the issue #132 
- I had made those `Divider()`'s transparent and converted those Paddings to Containers, even grouped some Paddings to a single Container to make them look better compared to the old UI.

## UI
### Light Mode
|Old| Redesigned|
|:-------|:-------|
| ![light](https://user-images.githubusercontent.com/83648898/222807560-86bf2b25-7f60-4aec-b9d5-8260fccf8957.png) | ![light](https://user-images.githubusercontent.com/83648898/222807617-d592a9d6-79ab-4e02-9837-d7f8a0b67e8b.png) |
### Dark Mode
|Old| Redesigned|
|:-------|:-------|
| ![dark](https://user-images.githubusercontent.com/83648898/222807721-c9b555f9-0d1b-4b82-ae1f-24df4aa8f77e.png) | ![dark](https://user-images.githubusercontent.com/83648898/222807753-5c86551a-3177-4646-9723-ce8d1d046a1a.png) |