### PR TITLE
Removed doubleTap for details

### DIFF
--- a/lib/widgets/addTask.dart
+++ b/lib/widgets/addTask.dart
@@ -235,7 +235,7 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
             Navigator.of(context).pop();
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                 content: const Text(
-                    'Task Added Successfully, Double tap to Edit'), // Intimating the user about the double tap to edit feature
+                    'Task Added Successfully, Tap to Edit'), // Intimating the user about the double tap to edit feature
                 backgroundColor: AppSettings.isDarkMode
                     ? const Color.fromARGB(255, 61, 61, 61)
                     : const Color.fromARGB(255, 39, 39, 39),

--- a/lib/widgets/buildTasks.dart
+++ b/lib/widgets/buildTasks.dart
@@ -262,7 +262,7 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                 splashColor: AppSettings.isDarkMode
                                     ? Colors.black
                                     : Colors.grey.shade200,
-                                onDoubleTap: () => Navigator.push(
+                                onTap: () => Navigator.push(
                                   context,
                                   MaterialPageRoute(
                                     builder: (context) => DetailRoute(task
@@ -285,7 +285,7 @@ class _TasksBuilderState extends State<TasksBuilder> {
                               splashColor: AppSettings.isDarkMode
                                   ? Colors.black
                                   : Colors.grey.shade200,
-                              onDoubleTap: () => Navigator.push(
+                              onTap: () => Navigator.push(
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => DetailRoute(task


### PR DESCRIPTION
fixes #137 
- Changed `onDoubleTap()` to `onTap()` for changing the double-tap to edit option to single-tap to edit.
- thus this pr will be resolving the issue #137 
## Working
### Before

https://user-images.githubusercontent.com/83648898/226216266-9f6707e4-05ba-40bc-8842-473f6dd9e72b.mp4

### After

https://user-images.githubusercontent.com/83648898/226216301-7abc38da-fe26-4546-ab5a-0d9947f52c7a.mp4

