### PR TITLE
fix: placeholder replaced on first load

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
 
 import 'package:loggy/loggy.dart';
 import 'package:path_provider/path_provider.dart';
@@ -38,16 +39,14 @@ Future main([List<String> args = const []]) async {
     ).createSync(recursive: true);
   }
 
+  Directory directory = await getApplicationDocumentsDirectory();
+  FlutterNativeSplash.remove();
+
   runApp(
-    FutureBuilder<Directory>(
-      future: getApplicationDocumentsDirectory(),
-      builder: (context, snapshot) => (snapshot.hasData)
-          ? ProfilesWidget(
-              baseDirectory: testingDirectory ?? snapshot.data!,
-              child: const MyApp(),
-            )
-          : const Placeholder(),
-    ),
+      ProfilesWidget(
+        baseDirectory: testingDirectory ?? directory,
+        child: const MyApp(),
+      )
   );
 }
 


### PR DESCRIPTION
Instead of returning placeholder, splash screen is displayed until directory loaded.
Loading of directory is awaited upon.
As soon as it is done, splash screen is popped from screen.

https://user-images.githubusercontent.com/27919652/229595821-bc1d68c3-a430-4ce4-8a7d-959732ae6043.mp4

solves #145 