### PR TITLE
Added timezone dependancy which was missing earlier

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -982,13 +982,13 @@ packages:
     source: hosted
     version: "0.4.16"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
-      sha256: "24c8fcdd49a805d95777a39064862133ff816ebfffe0ceff110fb5960e557964"
+      sha256: "1cfd8ddc2d1cfd836bc93e67b9be88c3adaeca6f40a00ca999104c30693cdca0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   import_sorter: ^4.6.0
   double_back_to_close_app: ^2.1.0
   permission_handler: ^10.2.0
+  timezone: ^0.9.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Before
<img width="1440" alt="Screenshot 2023-04-25 at 12 51 53 PM" src="https://user-images.githubusercontent.com/111864031/234205836-44efac30-669d-4093-9ba0-b0695c7ff889.png">
After
<img width="1440" alt="Screenshot 2023-04-25 at 12 52 17 PM" src="https://user-images.githubusercontent.com/111864031/234205895-f73f993a-526b-4cb5-8b17-c62c51797618.png">


Timezone Dependancy was missing 
Added - timezone: ^0.9.2