### PR TITLE
Upgrades 

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,10 +269,18 @@ packages:
     dependency: "direct main"
     description:
       name: file_selector
-      sha256: "3e7f5a2e97262989862ebe10d5d20076978c1ca3febfedff30d9d1d35e29ea55"
+      sha256: "1d2fde93dddf634a9c3c0faa748169d7ac0d83757135555707e52f02c017ad4f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.2+3"
+    version: "0.9.5"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: "65d41d2fbed893c5eb8842674ed08b920dc7d276b6c7e74ee8b1759dce4b2067"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   file_selector_ios:
     dependency: transitive
     description:
@@ -285,18 +293,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "3b998328a9531e3de5e55fcf0a5db6945d3d942049d637ac879460c972f4e10a"
+      sha256: "770eb1ab057b5ae4326d1c24cc57710758b9a46026349d021d6311bd27580046"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1+1"
+    version: "0.9.2"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "9fc34f918045299714bc616eb961dfb7fd499e45675a97376a0b01cfa4f60f20"
+      sha256: "7a6f1ae6107265664f3f7f89a66074882c4d506aef1441c9af313c1f7e6f41ce"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0+5"
+    version: "0.9.3"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -309,18 +317,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: "1038cf12fc355cf83cf9aa51a707c9acbc871caf8d9cdb0504638cafd6163426"
+      sha256: a890ca514f053e976ad7632cd1e665e2c4543d5acd82ec352a8d5709c55d6363
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0+3"
+    version: "0.9.1"
   file_selector_windows:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "466288883103abc67178266edaa0d2ac5e4a11b744a5bde6e18010c47570f75e"
+      sha256: "1372760c6b389842b77156203308940558a2817360154084368608413835fc26"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1+5"
+    version: "0.9.3"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.5
   date_format: ^2.0.6
   double_back_to_close_app: ^2.1.0
   file_picker_writable: ^2.0.3
-  file_selector: ^0.9.0
+  file_selector: ^0.9.4
   flutter:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
## Updated Dependencies -

- cupertino_icons: ^1.0.2 to 1.0.5
![Screenshot 2023-07-05 105624](https://github.com/CCExtractor/taskwarrior-flutter/assets/121665385/fa96bebb-20b9-4308-b623-2222e3367219)

- file_selector: ^0.9.0 to ^0.9.4
![Screenshot 2023-07-05 105634](https://github.com/CCExtractor/taskwarrior-flutter/assets/121665385/ca250bb2-0227-4c93-91f9-f0b2c1ec690c)


## Changes in these files -

![image](https://github.com/CCExtractor/taskwarrior-flutter/assets/121665385/07b4bf33-fb16-4336-bcb0-0f4d15bdc38e)
