### PR TITLE
Fix the picking of previous dates in add-task

### DIFF
--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -171,7 +171,7 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                     fieldHintText: "Month/Date/Year",
                     context: context,
                     initialDate: due ?? DateTime.now(),
-                    firstDate: DateTime(1990),
+                    firstDate: DateTime.now(),
                     lastDate: DateTime(2037, 12, 31),
                   );
                   if (date != null) {


### PR DESCRIPTION
# Description

Set the first date to the current date so that the user cannot pick a past date

## Fixes #211 

## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->
![1](https://github.com/CCExtractor/taskwarrior-flutter/assets/114338679/2487c49a-fe33-411d-87c4-55f28de41c7d)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing