### PR TITLE
Fix: Close previous snackbar when switching profiles

### DIFF
--- a/lib/widgets/profilefunctions/selectprofile.dart
+++ b/lib/widgets/profilefunctions/selectprofile.dart
@@ -112,6 +112,7 @@ class SelectProfileListTile extends StatelessWidget {
           groupValue: selectedUuid,
           onChanged: (_) {
             select();
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
               content: Text('Switched to Profile ${alias ?? uuid}'),
             ));


### PR DESCRIPTION
# Description

To close the previously opened Snackbar when switching between different files in Flutter, I have used the hideCurrentSnackBar method from the ScaffoldMessenger class right before displaying the new Snackbar. This method will immediately hide the current Snackbar, if any, and then the new Snackbar will be displayed.

## Fixes #218

## Screen Recording

https://github.com/CCExtractor/taskwarrior-flutter/assets/100941430/67976ac8-ab47-405a-b459-e434fa671194

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing