### PR TITLE
Fix Date Validation Error in Form

### DIFF
--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -88,6 +88,7 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
   }
 
   Widget buildName() => TextFormField(
+        autofocus: true,
         controller: namecontroller,
         style: TextStyle(
           color: AppSettings.isDarkMode ? Colors.white : Colors.black,
@@ -121,14 +122,14 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                 ),
                 readOnly: true,
                 controller: TextEditingController(
-                  text: (due != null) ? dueString : "  Select due date",
+                  text: (due != null) ? dueString : null,
                 ),
                 decoration: InputDecoration(
                   hintText: 'Select due date',
                   hintStyle: TextStyle(
                     color: AppSettings.isDarkMode ? Colors.white : Colors.black,
                   ),
-                  errorText: (due == null) ? 'Due date is required' : null,
+                  // errorText: (due == null) ? 'Due date is required' : null,
                 ),
                 validator: (name) => name != null && name.isEmpty
                     ? 'due date is required'
@@ -321,8 +322,12 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
         if (formKey.currentState!.validate()) {
           if (due == null) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: const Text(
-                  'Due date cannot be empty. Please select a due date.'),
+              content: Text(
+                'Due date cannot be empty. Please select a due date.',
+                style: TextStyle(
+                  color: AppSettings.isDarkMode ? Colors.white : Colors.black,
+                ),
+              ),
               backgroundColor:
                   AppSettings.isDarkMode ? Colors.black : Colors.white,
               duration: const Duration(seconds: 2),
@@ -343,7 +348,12 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
             widgetController.fetchAllData();
 
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: const Text('Task Added Successfully, Tap to Edit'),
+              content: Text(
+                'Task Added Successfully, Tap to Edit',
+                style: TextStyle(
+                  color: AppSettings.isDarkMode ? Colors.white : Colors.black,
+                ),
+              ),
               backgroundColor:
                   AppSettings.isDarkMode ? Colors.black : Colors.white,
               duration: const Duration(seconds: 2),
@@ -360,7 +370,12 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
             }
           } on FormatException catch (e) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text(e.message),
+              content: Text(
+                e.message,
+                style: TextStyle(
+                  color: AppSettings.isDarkMode ? Colors.white : Colors.black,
+                ),
+              ),
               backgroundColor: AppSettings.isDarkMode
                   ? const Color.fromARGB(255, 61, 61, 61)
                   : const Color.fromARGB(255, 39, 39, 39),

--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -129,7 +129,6 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                   hintStyle: TextStyle(
                     color: AppSettings.isDarkMode ? Colors.white : Colors.black,
                   ),
-                  // errorText: (due == null) ? 'Due date is required' : null,
                 ),
                 validator: (name) => name != null && name.isEmpty
                     ? 'due date is required'


### PR DESCRIPTION
# Description

The validator functions for FormField widgets return either null or a string, indicating validity. If a validator returns a string, the form is considered invalid. The issue arises from the buildDueDate widget, which consistently assigns a string value to the controller. I debugged the TextEditingController and removed unnecessary use of errorText in the widget

## Fixes #226 

## Screenshots


<img src="https://github.com/CCExtractor/taskwarrior-flutter/assets/100941430/634aaaf4-9a8f-437a-aef3-3e60146229b0" width="200" alt="Screenshot_1703499059">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing