### PR TITLE
Fixes setting past time

### DIFF
--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -212,7 +212,7 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                       },
                       context: context,
                       initialTime:
-                          TimeOfDay.fromDateTime(due ?? DateTime.now()),
+                          TimeOfDay.now(),
                     );
                     if (time != null) {
                       var dateTime = date.add(
@@ -226,7 +226,16 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                           hours: time.hour - dateTime.hour,
                         ),
                       );
-                      due = dateTime.toUtc();
+                      // Check if the selected time is in the past
+                      if (dateTime.isBefore(DateTime.now())) {
+                        // Show a message that past times can't be set
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text("Can't set times in the past")),
+                        );
+                      } else {
+                        // If the time is not in the past, proceed as usual
+                        due=dateTime.toUtc();
+                      }
                       NotificationService notificationService =
                           NotificationService();
                       notificationService.initiliazeNotification();

--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -212,7 +212,8 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                       },
                       context: context,
                       initialTime:
-                          TimeOfDay.now(),
+                          TimeOfDay.fromDateTime(due ?? DateTime.now()),
+                          // TimeOfDay.now(),
                     );
                     if (time != null) {
                       var dateTime = date.add(
@@ -226,16 +227,17 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                           hours: time.hour - dateTime.hour,
                         ),
                       );
-                      // Check if the selected time is in the past
-                      if (dateTime.isBefore(DateTime.now())) {
-                        // Show a message that past times can't be set
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text("Can't set times in the past")),
-                        );
-                      } else {
-                        // If the time is not in the past, proceed as usual
-                        due=dateTime.toUtc();
-                      }
+                      // // Check if the selected time is in the past
+                      // if (dateTime.isBefore(DateTime.now())) {
+                      //   // Show a message that past times can't be set
+                      //   ScaffoldMessenger.of(context).showSnackBar(
+                      //     const SnackBar(content: Text("Can't set times in the past")),
+                      //   );
+                      // } else {
+                      //   // If the time is not in the past, proceed as usual
+                      //   due=dateTime.toUtc();
+                      // }
+                      due=dateTime.toUtc();
                       NotificationService notificationService =
                           NotificationService();
                       notificationService.initiliazeNotification();

--- a/lib/widgets/taskdetails/dateTimePicker.dart
+++ b/lib/widgets/taskdetails/dateTimePicker.dart
@@ -74,7 +74,7 @@ class DateTimeWidget extends StatelessWidget {
           if (date != null) {
             var time = await showTimePicker(
               context: context,
-              initialTime: TimeOfDay.fromDateTime(initialDate),
+              initialTime: TimeOfDay.now(),
             );
             if (time != null) {
               var dateTime = date.add(
@@ -88,7 +88,16 @@ class DateTimeWidget extends StatelessWidget {
                   hours: time.hour - dateTime.hour,
                 ),
               );
-              return callback(dateTime.toUtc());
+              // Check if the selected time is in the past
+              if (dateTime.isBefore(DateTime.now())) {
+                // Show a message that past times can't be set
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text("Can't set times in the past")),
+                );
+              } else {
+                // If the time is not in the past, proceed as usual
+                return callback(dateTime.toUtc());
+              }
             }
           }
         },


### PR DESCRIPTION
fix #249 
The fix implemented in this PR prevents the setting of past times. Now, if a user attempts to set a time in the past, a message is displayed: “Can’t set times in the past”. This ensures that tasks cannot be assigned times that have already passed, enhancing the user experience and task management efficiency.

https://github.com/CCExtractor/taskwarrior-flutter/assets/143318563/d2f650f3-9ce7-4bd7-ad66-9d350cfedb73

