### PR TITLE
fixes timezone

### DIFF
--- a/lib/services/task_details.dart
+++ b/lib/services/task_details.dart
@@ -208,13 +208,10 @@ class AttributeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var localValue = (value is DateTime)
-        ? DateFormat.yMEd().add_jms().format(value)
-        : ((value is BuiltList) ? (value).toBuilder() : value);
-
-    //   var localValue = (value is DateTime)
-    // ? (value as DateTime).toLocal()
-    // : ((value is BuiltList) ? (value as BuiltList).toBuilder() : value);
+  var localValue = (value is DateTime)
+    ? DateFormat.yMEd().add_jms().format(value.toLocal())
+    : ((value is BuiltList) ? (value).toBuilder() : value);
+    
     switch (name) {
       case 'description':
         return DescriptionWidget(


### PR DESCRIPTION
Fixes #248 
The fix ensures correct time zone conversion and display. Now, when a user sets a time, it is displayed as entered by the user, adhering to the user’s local time zone. This fix enhances the user experience by eliminating potential confusion and mismanagement of tasks due to time zone discrepancies.

https://github.com/CCExtractor/taskwarrior-flutter/assets/143318563/4cde310b-c77e-4463-ad65-13657d9aa866

