### PR TITLE
filter_menu_problem_solved

### DIFF
--- a/lib/widgets/project_filter.dart
+++ b/lib/widgets/project_filter.dart
@@ -216,6 +216,7 @@ class ProjectTile extends StatelessWidget {
           )
         : ExpansionTile(
             controlAffinity: ListTileControlAffinity.leading,
+            key: PageStorageKey(project),
             leading: radio,
             title: title,
             backgroundColor: AppSettings.isDarkMode


### PR DESCRIPTION
# Description

Earlier, when a sub-project was added, the filter screen was crashing. This issue arose because the ExpansionTile didn't inherently remember whether it was expanded or collapsed. To address this, a PageStorageKey was introduced. Now, with dynamically assigned keys based on the project name, each ExpansionTile retains its unique state, preventing crashes and ensuring a smooth user experience.


## Fixes #244 



## Screenshots


https://github.com/CCExtractor/taskwarrior-flutter/assets/115138974/379fb0ab-87d0-407b-bd1e-42956b964500



## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing