### PR TITLE
Navigation bug fix for yes button

### DIFF
--- a/lib/services/task_details.dart
+++ b/lib/services/task_details.dart
@@ -78,7 +78,10 @@ class _DetailRouteState extends State<DetailRoute> {
                 TextButton(
                   onPressed: () {
                     saveChanges();
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pushNamedAndRemoveUntil(
+                      HomePage.routeName,
+                      (route) => false,
+                    );
                     setState(() {});
                   },
                   child: const Text('Yes'),
@@ -208,10 +211,10 @@ class AttributeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-  var localValue = (value is DateTime)
-    ? DateFormat.yMEd().add_jms().format(value.toLocal())
-    : ((value is BuiltList) ? (value).toBuilder() : value);
-    
+    var localValue = (value is DateTime)
+        ? DateFormat.yMEd().add_jms().format(value.toLocal())
+        : ((value is BuiltList) ? (value).toBuilder() : value);
+
     switch (name) {
       case 'description':
         return DescriptionWidget(


### PR DESCRIPTION
# Description

Replaced Navigator.pop(context) with Navigator.of(context).pushNamedAndRemoveUntil(HomePage.routeName, (route) => false) to resolve a crash in debug mode and freezing in non-debug mode. The change clears the entire navigation stack, preventing memory issues and ensuring a reliable navigation flow.

## Fixes #256 



## Screenshots

https://github.com/CCExtractor/taskwarrior-flutter/assets/115138974/6054569a-49bb-480d-a252-213932a53901



## Checklist

<!-- Mark the completed tasks with [x] -->

- [x] Code follows the established coding style guidelines
- [x] All tests are passing