### PR TITLE
fixed Unnecessary Alert on Unchanged Task Page Exit

### DIFF
--- a/lib/services/task_details.dart
+++ b/lib/services/task_details.dart
@@ -24,6 +24,7 @@ class DetailRoute extends StatefulWidget {
 
 class _DetailRouteState extends State<DetailRoute> {
   late Modify modify;
+  bool isModified = false;
 
   @override
   void didChangeDependencies() {
@@ -37,6 +38,7 @@ class _DetailRouteState extends State<DetailRoute> {
   }
 
   void Function(dynamic) callback(String name) {
+    isModified = true;
     return (newValue) {
       modify.set(name, newValue);
       setState(() {});
@@ -61,7 +63,7 @@ class _DetailRouteState extends State<DetailRoute> {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: false,
+      canPop: !isModified,
       onPopInvoked: (bool didPop) async {
         if (didPop) {
           await Navigator.of(context).pushAndRemoveUntil(


### PR DESCRIPTION
# Description

I have fixed the Unnecessary Alert on Unchanged Task Page according to #260 by adding a Boolean variable isModified initialized with false and assigned true when callback() function is called to forther use it in canPop paramenter of popScope in task_details.dart at line number 66   

## Fixes #260 Unnecessary Alert on Unchanged Task Page

- fixed 

## Screenshots


https://github.com/CCExtractor/taskwarrior-flutter/assets/58760825/fe2d1946-0bc9-4a8c-8c04-1500d0725f13



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [] All tests are passing