### PR TITLE
search key issue solved

### DIFF
--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -52,7 +52,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   final addKey = GlobalKey();
-  final searchKey = GlobalKey();
+  final searchKey1 = GlobalKey();
+  final searchKey2 = GlobalKey();
   final filterKey = GlobalKey();
   final menuKey = GlobalKey();
   final refreshKey = GlobalKey();
@@ -64,7 +65,7 @@ class _HomePageState extends State<HomePage> {
     tutorialCoachMark = TutorialCoachMark(
         targets: addTargetsPage(
           addKey: addKey,
-          searchKey: searchKey,
+          searchKey: searchKey1,
           filterKey: filterKey,
           menuKey: menuKey,
           refreshKey: refreshKey,
@@ -206,7 +207,7 @@ class _HomePageState extends State<HomePage> {
             Text('Home Page', style: GoogleFonts.poppins(color: Colors.white)),
         actions: [
           IconButton(
-            key: searchKey,
+            key: searchKey1,
             icon: (storageWidget.searchVisible)
                 ? const Tooltip(
                     message: 'Cancel',
@@ -278,7 +279,7 @@ class _HomePageState extends State<HomePage> {
               children: <Widget>[
                 if (storageWidget.searchVisible)
                   Container(
-                    key: searchKey,
+                    key: searchKey2,
                     margin: const EdgeInsets.symmetric(
                         horizontal: 10, vertical: 10),
                     child: SearchBar(


### PR DESCRIPTION
# Description

Previously, when clicking on the search icon, the app crashed due to the use of multiple search keys for both the search icon and the search bar. To address this, I added two different search keys to both components.

## Fixes #280 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing