### PR TITLE
Negative Number Display Bug Fixed

### DIFF
--- a/lib/widgets/taskfunctions/datetime_differences.dart
+++ b/lib/widgets/taskfunctions/datetime_differences.dart
@@ -21,5 +21,8 @@ String difference(Duration difference) {
   } else {
     result = '${difference.abs().inSeconds}s';
   }
-  return '${(difference.isNegative) ? '-' : ''}$result';
+  if (difference.isNegative) {
+    result = '0s';
+  }
+  return result;
 }


### PR DESCRIPTION
# Description

Earlier, when the due date was marked as completed, the task tile used to display a negative number. I have replaced it with zero, as it signifies that the task's due date has passed.

## Fixes #279 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

https://github.com/CCExtractor/taskwarrior-flutter/assets/115138974/cf2c4cd3-6610-42f0-adae-2a149a1f7260

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing