### PR TITLE
Updated the null check condition on taskserver page

### DIFF
--- a/lib/drawer/nav_drawer.dart
+++ b/lib/drawer/nav_drawer.dart
@@ -8,6 +8,7 @@ import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/views/about/about.dart';
 import 'package:taskwarrior/views/profile/profile.dart';
 import 'package:taskwarrior/views/reports/reports_home.dart';
@@ -211,7 +212,7 @@ Future<void> _showExitConfirmationDialog(BuildContext context) async {
     context: context,
     barrierDismissible: false, // Prevents closing the dialog by tapping outside
     builder: (BuildContext context) {
-      return AlertDialog(
+      return Utils.showAlertDialog(
         surfaceTintColor: AppSettings.isDarkMode
             ? TaskWarriorColors.kdialogBackGroundColor
             : TaskWarriorColors.kLightDialogBackGroundColor,

--- a/lib/drawer/nav_drawer.dart
+++ b/lib/drawer/nav_drawer.dart
@@ -213,15 +213,6 @@ Future<void> _showExitConfirmationDialog(BuildContext context) async {
     barrierDismissible: false, // Prevents closing the dialog by tapping outside
     builder: (BuildContext context) {
       return Utils.showAlertDialog(
-        surfaceTintColor: AppSettings.isDarkMode
-            ? TaskWarriorColors.kdialogBackGroundColor
-            : TaskWarriorColors.kLightDialogBackGroundColor,
-        shadowColor: AppSettings.isDarkMode
-            ? TaskWarriorColors.kdialogBackGroundColor
-            : TaskWarriorColors.kLightDialogBackGroundColor,
-        backgroundColor: AppSettings.isDarkMode
-            ? TaskWarriorColors.kdialogBackGroundColor
-            : TaskWarriorColors.kLightDialogBackGroundColor,
         title: Text(
           'Exit App',
           style: TextStyle(

--- a/lib/services/task_details.dart
+++ b/lib/services/task_details.dart
@@ -10,6 +10,7 @@ import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/views/home/home.dart';
 import 'package:taskwarrior/widgets/pallete.dart';
 import 'package:taskwarrior/widgets/taskdetails.dart';
@@ -86,16 +87,7 @@ class _DetailRouteState extends State<DetailRoute> {
         return showDialog(
           context: context,
           builder: (context) {
-            return AlertDialog(
-              surfaceTintColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              shadowColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              backgroundColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
+            return Utils.showAlertDialog(
               title: Text(
                 'Do you want to save changes?',
                 style: TextStyle(
@@ -219,16 +211,7 @@ class _DetailRouteState extends State<DetailRoute> {
                   showDialog(
                     context: context,
                     builder: (context) {
-                      return AlertDialog(
-                        surfaceTintColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.kdialogBackGroundColor
-                            : TaskWarriorColors.kLightDialogBackGroundColor,
-                        shadowColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.kdialogBackGroundColor
-                            : TaskWarriorColors.kLightDialogBackGroundColor,
-                        backgroundColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.kdialogBackGroundColor
-                            : TaskWarriorColors.kLightDialogBackGroundColor,
+                      return Utils.showAlertDialog(
                         scrollable: true,
                         title: Text(
                           'Review changes:',

--- a/lib/taskserver/ntaskserver.dart
+++ b/lib/taskserver/ntaskserver.dart
@@ -840,7 +840,9 @@ class _PemWidgetState extends State<PemWidget> {
     var name = widget.storage.guiPemFiles.pemFilename(widget.pem);
     String identifier = "";
     try {
-      identifier = fingerprint(contents!).toUpperCase();
+      if (contents != null) {
+        identifier = fingerprint(contents).toUpperCase(); // Null check removed
+      }
     } catch (e) {
       debugPrint(e.toString());
     }

--- a/lib/taskserver/ntaskserver.dart
+++ b/lib/taskserver/ntaskserver.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:loggy/loggy.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/taskdetails/profiles_widget.dart';
 // ignore_for_file: use_build_context_synchronously
 
@@ -77,16 +78,7 @@ class _ManageTaskServerState extends State<ManageTaskServer> {
       context: context,
       barrierDismissible: false,
       builder: (context) {
-        return AlertDialog(
-          surfaceTintColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          shadowColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          backgroundColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
+        return Utils.showAlertDialog(
           title: const Text('Fetching statistics...'),
           content: const Column(
             mainAxisSize: MainAxisSize.min,
@@ -114,16 +106,7 @@ class _ManageTaskServerState extends State<ManageTaskServer> {
       // Show statistics in a dialog
       await showDialog(
         context: context,
-        builder: (context) => AlertDialog(
-          surfaceTintColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          shadowColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          backgroundColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
+        builder: (context) => Utils.showAlertDialog(
           scrollable: true,
           title: Text(
             'Statistics:',

--- a/lib/utility/utilities.dart
+++ b/lib/utility/utilities.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:taskwarrior/config/app_settings.dart';
+import 'package:taskwarrior/config/taskwarriorcolors.dart';
 
 class Utils {
   static String getWeekNumber(DateTime? date) {
@@ -47,5 +50,66 @@ class Utils {
       default:
         return '';
     }
+  }
+
+  static AlertDialog showAlertDialog({
+    Key? key,
+    Widget? icon,
+    EdgeInsetsGeometry? iconPadding,
+    Color? iconColor,
+    Widget? title,
+    EdgeInsetsGeometry? titlePadding,
+    TextStyle? titleTextStyle,
+    Widget? content,
+    EdgeInsetsGeometry? contentPadding,
+    TextStyle? contentTextStyle,
+    List<Widget>? actions,
+    EdgeInsetsGeometry? actionsPadding,
+    MainAxisAlignment? actionsAlignment,
+    OverflowBarAlignment? actionsOverflowAlignment,
+    VerticalDirection? actionsOverflowDirection,
+    double? actionsOverflowButtonSpacing,
+    EdgeInsetsGeometry? buttonPadding,
+    Color? backgroundColor,
+    double? elevation,
+    Color? shadowColor,
+    Color? surfaceTintColor,
+    String? semanticLabel,
+    Clip clipBehavior = Clip.none,
+    ShapeBorder? shape,
+    AlignmentGeometry? alignment,
+    bool scrollable = false,
+  }) {
+    return AlertDialog(
+      surfaceTintColor: AppSettings.isDarkMode
+          ? TaskWarriorColors.kdialogBackGroundColor
+          : TaskWarriorColors.kLightDialogBackGroundColor,
+      shadowColor: AppSettings.isDarkMode
+          ? TaskWarriorColors.kdialogBackGroundColor
+          : TaskWarriorColors.kLightDialogBackGroundColor,
+      backgroundColor: AppSettings.isDarkMode
+          ? TaskWarriorColors.kdialogBackGroundColor
+          : TaskWarriorColors.kLightDialogBackGroundColor,
+      key: key,
+      title: title,
+      titlePadding: titlePadding,
+      titleTextStyle: titleTextStyle,
+      content: content,
+      contentPadding: contentPadding,
+      contentTextStyle: contentTextStyle,
+      actions: actions,
+      actionsPadding: actionsPadding,
+      actionsAlignment: actionsAlignment,
+      actionsOverflowAlignment: actionsOverflowAlignment,
+      actionsOverflowDirection: actionsOverflowDirection,
+      actionsOverflowButtonSpacing: actionsOverflowButtonSpacing,
+      buttonPadding: buttonPadding,
+      elevation: elevation,
+      semanticLabel: semanticLabel,
+      clipBehavior: clipBehavior,
+      shape: shape,
+      alignment: alignment,
+      scrollable: scrollable,
+    );
   }
 }

--- a/lib/views/profile/profile.dart
+++ b/lib/views/profile/profile.dart
@@ -5,6 +5,7 @@ import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/model/storage/savefile.dart';
 import 'package:taskwarrior/taskserver/ntaskserver.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/pallete.dart';
 import 'package:taskwarrior/widgets/profilefunctions.dart';
 import 'package:taskwarrior/widgets/taskdetails.dart';
@@ -85,16 +86,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 showDialog(
                   context: context,
                   builder: (BuildContext context) {
-                    return AlertDialog(
-                      surfaceTintColor: AppSettings.isDarkMode
-                          ? TaskWarriorColors.kdialogBackGroundColor
-                          : TaskWarriorColors.kLightDialogBackGroundColor,
-                      shadowColor: AppSettings.isDarkMode
-                          ? TaskWarriorColors.kdialogBackGroundColor
-                          : TaskWarriorColors.kLightDialogBackGroundColor,
-                      backgroundColor: AppSettings.isDarkMode
-                          ? TaskWarriorColors.kdialogBackGroundColor
-                          : TaskWarriorColors.kLightDialogBackGroundColor,
+                    return Utils.showAlertDialog(
                       title: Text(
                         "Export Format",
                         style: TextStyle(

--- a/lib/views/settings/settings.dart
+++ b/lib/views/settings/settings.dart
@@ -10,6 +10,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/pallete.dart';
 import 'package:taskwarrior/widgets/taskdetails/profiles_widget.dart';
 
@@ -260,22 +261,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                 showDialog(
                                   context: context,
                                   builder: (BuildContext context) {
-                                    return AlertDialog(
-                                      surfaceTintColor: AppSettings.isDarkMode
-                                          ? TaskWarriorColors
-                                              .kdialogBackGroundColor
-                                          : TaskWarriorColors
-                                              .kLightDialogBackGroundColor,
-                                      shadowColor: AppSettings.isDarkMode
-                                          ? TaskWarriorColors
-                                              .kdialogBackGroundColor
-                                          : TaskWarriorColors
-                                              .kLightDialogBackGroundColor,
-                                      backgroundColor: AppSettings.isDarkMode
-                                          ? TaskWarriorColors
-                                              .kdialogBackGroundColor
-                                          : TaskWarriorColors
-                                              .kLightDialogBackGroundColor,
+                                    return Utils.showAlertDialog(
                                       title: Text(
                                         'Reset to default',
                                         style: GoogleFonts.poppins(
@@ -414,16 +400,7 @@ class _SettingsPageState extends State<SettingsPage> {
             showDialog(
               context: context,
               builder: (BuildContext context) {
-                return AlertDialog(
-                  surfaceTintColor: AppSettings.isDarkMode
-                      ? TaskWarriorColors.kdialogBackGroundColor
-                      : TaskWarriorColors.kLightDialogBackGroundColor,
-                  shadowColor: AppSettings.isDarkMode
-                      ? TaskWarriorColors.kdialogBackGroundColor
-                      : TaskWarriorColors.kLightDialogBackGroundColor,
-                  backgroundColor: AppSettings.isDarkMode
-                      ? TaskWarriorColors.kdialogBackGroundColor
-                      : TaskWarriorColors.kLightDialogBackGroundColor,
+                return Utils.showAlertDialog(
                   title: Text(
                     'Error',
                     style: GoogleFonts.poppins(

--- a/lib/widgets/add_Task.dart
+++ b/lib/widgets/add_Task.dart
@@ -12,6 +12,7 @@ import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
 import 'package:taskwarrior/controller/WidgetController.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/taskfunctions/taskparser.dart';
 import 'package:taskwarrior/widgets/taskw.dart';
 
@@ -49,16 +50,7 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
 
     return Center(
       child: SingleChildScrollView(
-        child: AlertDialog(
-          surfaceTintColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          shadowColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          backgroundColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
+        child: Utils.showAlertDialog(
           title: Center(
             child: Text(
               title,

--- a/lib/widgets/profilefunctions/deleteprofiledialog.dart
+++ b/lib/widgets/profilefunctions/deleteprofiledialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/taskdetails/profiles_widget.dart';
 
 class DeleteProfileDialog extends StatelessWidget {
@@ -19,16 +20,7 @@ class DeleteProfileDialog extends StatelessWidget {
     return Center(
       child: SingleChildScrollView(
         child: Center(
-          child: AlertDialog(
-            surfaceTintColor: AppSettings.isDarkMode
-                ? TaskWarriorColors.kdialogBackGroundColor
-                : TaskWarriorColors.kLightDialogBackGroundColor,
-            shadowColor: AppSettings.isDarkMode
-                ? TaskWarriorColors.kdialogBackGroundColor
-                : TaskWarriorColors.kLightDialogBackGroundColor,
-            backgroundColor: AppSettings.isDarkMode
-                ? TaskWarriorColors.kdialogBackGroundColor
-                : TaskWarriorColors.kLightDialogBackGroundColor,
+          child: Utils.showAlertDialog(
             scrollable: true,
             title: Text(
               'Delete Profile?',

--- a/lib/widgets/profilefunctions/renameprofiledialog.dart
+++ b/lib/widgets/profilefunctions/renameprofiledialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 
 import 'package:taskwarrior/widgets/taskdetails.dart';
 
@@ -22,16 +23,7 @@ class RenameProfileDialog extends StatelessWidget {
 
     return SingleChildScrollView(
       child: Center(
-        child: AlertDialog(
-          surfaceTintColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          shadowColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
-          backgroundColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kdialogBackGroundColor
-              : TaskWarriorColors.kLightDialogBackGroundColor,
+        child: Utils.showAlertDialog(
           scrollable: true,
           title: Text(
             'Rename Alias',

--- a/lib/widgets/taskdetails/description_widget.dart
+++ b/lib/widgets/taskdetails/description_widget.dart
@@ -6,6 +6,7 @@ import 'package:loggy/loggy.dart';
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 
 class DescriptionWidget extends StatelessWidget {
   const DescriptionWidget(
@@ -66,16 +67,7 @@ class DescriptionWidget extends StatelessWidget {
           );
           showDialog(
             context: context,
-            builder: (context) => AlertDialog(
-              surfaceTintColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              shadowColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              backgroundColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
+            builder: (context) => Utils.showAlertDialog(
               scrollable: true,
               title: Text(
                 'Edit description',
@@ -195,16 +187,7 @@ class ProjectWidget extends StatelessWidget {
           );
           showDialog(
             context: context,
-            builder: (context) => AlertDialog(
-              surfaceTintColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              shadowColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              backgroundColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
+            builder: (context) => Utils.showAlertDialog(
               scrollable: true,
               title: Text(
                 'Edit project',

--- a/lib/widgets/taskdetails/tags_widget.dart
+++ b/lib/widgets/taskdetails/tags_widget.dart
@@ -8,6 +8,7 @@ import 'package:loggy/loggy.dart';
 import 'package:taskwarrior/config/app_settings.dart';
 import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
+import 'package:taskwarrior/utility/utilities.dart';
 import 'package:taskwarrior/widgets/taskw.dart';
 
 class TagsWidget extends StatelessWidget {
@@ -194,16 +195,7 @@ class TagsRouteState extends State<TagsRoute> {
           var controller = TextEditingController();
           showDialog(
             context: context,
-            builder: (context) => AlertDialog(
-              surfaceTintColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              shadowColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              backgroundColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
+            builder: (context) => Utils.showAlertDialog(
               scrollable: true,
               title: Text(
                 'Add tag',


### PR DESCRIPTION
# Description

The null check operator (!) is used in Dart to assert that a value is non-null, and it tells the Dart analyzer to treat the expression as if the value cannot be null. So I have updated the null check operator, now it is only used when contents variable is non-null, avoiding the runtime error.

## Fixes #305 

## Screenshots
![null](https://github.com/CCExtractor/taskwarrior-flutter/assets/114338679/b17cae23-9cfe-4744-81e3-f2ba6c20ba6b)

<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing