### PR TITLE
Dev

### DIFF
--- a/lib/widgets/buildTasks.dart
+++ b/lib/widgets/buildTasks.dart
@@ -11,10 +11,11 @@ import 'package:taskwarrior/config/taskwarriorcolors.dart';
 import 'package:taskwarrior/config/taskwarriorfonts.dart';
 import 'package:taskwarrior/model/json.dart';
 import 'package:taskwarrior/model/storage/storage_widget.dart';
+import 'package:taskwarrior/services/notification_services.dart';
 import 'package:taskwarrior/services/task_details.dart';
 import 'package:taskwarrior/services/task_list_tem.dart';
 import 'package:taskwarrior/widgets/taskfunctions/modify.dart';
-import '../services/notification_services.dart';
+
 import 'pallete.dart';
 
 class TasksBuilder extends StatefulWidget {
@@ -219,7 +220,7 @@ class _TasksBuilderState extends State<TasksBuilder> {
                               motion: const DrawerMotion(),
                               children: [
                                 SlidableAction(
-                                  onPressed: (context) async {
+                                  onPressed: (context) {
                                     // Delete task without confirmation
                                     setStatus('deleted', task.uuid);
                                     if (task.due != null) {

--- a/lib/widgets/buildTasks.dart
+++ b/lib/widgets/buildTasks.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -15,6 +14,7 @@ import 'package:taskwarrior/model/storage/storage_widget.dart';
 import 'package:taskwarrior/services/task_details.dart';
 import 'package:taskwarrior/services/task_list_tem.dart';
 import 'package:taskwarrior/widgets/taskfunctions/modify.dart';
+import '../services/notification_services.dart';
 import 'pallete.dart';
 
 class TasksBuilder extends StatefulWidget {
@@ -191,13 +191,15 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                       DateTime? dtb = task.due;
                                       dtb =
                                           dtb!.add(const Duration(minutes: 1));
-                                      final FlutterLocalNotificationsPlugin
-                                          flutterLocalNotificationsPlugin =
-                                          FlutterLocalNotificationsPlugin();
-                                      flutterLocalNotificationsPlugin.cancel(
-                                          dtb.day * 100 +
-                                              dtb.hour * 10 +
-                                              dtb.minute);
+                                      NotificationService notificationService =
+                                          NotificationService();
+                                      //Task ID is set to null when creating the notification id.
+                                      int notificationId = notificationService
+                                          .calculateNotificationId(task.due!,
+                                              task.description, null);
+                                      notificationService
+                                          .cancelNotification(notificationId);
+
                                       if (kDebugMode) {
                                         print("Task due is $dtb");
                                         print(dtb.day * 100 +
@@ -217,20 +219,24 @@ class _TasksBuilderState extends State<TasksBuilder> {
                               motion: const DrawerMotion(),
                               children: [
                                 SlidableAction(
-                                  onPressed: (context) {
+                                  onPressed: (context) async {
                                     // Delete task without confirmation
                                     setStatus('deleted', task.uuid);
                                     if (task.due != null) {
                                       DateTime? dtb = task.due;
                                       dtb =
                                           dtb!.add(const Duration(minutes: 1));
-                                      final FlutterLocalNotificationsPlugin
-                                          flutterLocalNotificationsPlugin =
-                                          FlutterLocalNotificationsPlugin();
-                                      flutterLocalNotificationsPlugin.cancel(
-                                          dtb.day * 100 +
-                                              dtb.hour * 10 +
-                                              dtb.minute);
+
+                                      //Task ID is set to null when creating the notification id.
+                                      NotificationService notificationService =
+                                          NotificationService();
+
+                                      int notificationId = notificationService
+                                          .calculateNotificationId(task.due!,
+                                              task.description, null);
+                                      notificationService
+                                          .cancelNotification(notificationId);
+
                                       if (kDebugMode) {
                                         print("Task due is $dtb");
                                         print(dtb.day * 100 +


### PR DESCRIPTION
# Description

Notification was supposed to be cancelled once task is deleted or completed but it was not working.
I've used the Notification service to get the task id by calculating it again since it was not saved and used it to delete the task.
Note that when calculating the notificationId the task id, which is an input, is given as null. 

## Fixes #320 


## Screenshots

N/A

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing