### PR TITLE
Due & issue notification issues solved

### DIFF
--- a/lib/model/data.dart
+++ b/lib/model/data.dart
@@ -154,13 +154,20 @@ class Data {
 
     if (task.status == 'pending' && task.due != null) {
       int notificationid = notificationService.calculateNotificationId(
-          task.due!, task.description, task.id);
+          task.due!, task.description, false, task.entry);
       notificationService.cancelNotification(notificationid);
       notificationService.sendNotification(
-          task.due!, task.description, task.id);
+          task.due!, task.description, false, task.entry);
+      if (task.wait != null) {
+        int waitNotificationId = notificationService.calculateNotificationId(
+            task.wait!, task.description, true, task.entry);
+        notificationService.cancelNotification(waitNotificationId);
+        notificationService.sendNotification(
+            task.wait!, task.description, true, task.entry);
+      }
     } else if (task.due != null) {
       int notificationid = notificationService.calculateNotificationId(
-          task.due!, task.description, task.id);
+          task.due!, task.description, false, task.entry);
 
       notificationService.cancelNotification(notificationid);
     }

--- a/lib/widgets/buildTasks.dart
+++ b/lib/widgets/buildTasks.dart
@@ -192,14 +192,8 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                       DateTime? dtb = task.due;
                                       dtb =
                                           dtb!.add(const Duration(minutes: 1));
-                                      NotificationService notificationService =
-                                          NotificationService();
-                                      //Task ID is set to null when creating the notification id.
-                                      int notificationId = notificationService
-                                          .calculateNotificationId(task.due!,
-                                              task.description, null);
-                                      notificationService
-                                          .cancelNotification(notificationId);
+
+                                      cancelNotification(task);
 
                                       if (kDebugMode) {
                                         print("Task due is $dtb");
@@ -229,14 +223,7 @@ class _TasksBuilderState extends State<TasksBuilder> {
                                           dtb!.add(const Duration(minutes: 1));
 
                                       //Task ID is set to null when creating the notification id.
-                                      NotificationService notificationService =
-                                          NotificationService();
-
-                                      int notificationId = notificationService
-                                          .calculateNotificationId(task.due!,
-                                              task.description, null);
-                                      notificationService
-                                          .cancelNotification(notificationId);
+                                      cancelNotification(task);
 
                                       if (kDebugMode) {
                                         print("Task due is $dtb");
@@ -300,5 +287,20 @@ class _TasksBuilderState extends State<TasksBuilder> {
                           ),
                 ],
               ));
+  }
+
+  void cancelNotification(Task task) {
+    //Task ID is set to null when creating the notification id.
+    NotificationService notificationService = NotificationService();
+
+    int notificationId = notificationService.calculateNotificationId(
+        task.due!, task.description, false, task.entry);
+    notificationService.cancelNotification(notificationId);
+
+    if (task.wait != null) {
+      notificationId = notificationService.calculateNotificationId(
+          task.wait!, task.description, true, task.entry);
+      notificationService.cancelNotification(notificationId);
+    }
   }
 }


### PR DESCRIPTION
# Description
The Due notification was being issued twice when adjusting it, once in the past time and once in the adjusted time.
When adding wait time, the notification is issued twice for no reason.

I've solved that by creating a waitNotificationID and itself reads if the task.wait was initialized or not.


## Fixes #(319 & 326)


## Screenshots
Check out the result in this video:
https://drive.google.com/file/d/11EB8CacRbrrRnCZl7uMBuRyxViPOZLmp/view?usp=sharing



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing