### PR TITLE
fix: macOS build due to permission handler plugin

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import flutter_local_notifications
 import flutter_native_timezone
 import package_info_plus
 import path_provider_foundation
+import permission_handler_apple
 import shared_preferences_foundation
 import url_launcher_macos
 
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  PermissionHandlerPlugin.register(with: registry.registrar(forPlugin: "PermissionHandlerPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -624,30 +624,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -676,26 +652,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -740,10 +716,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -811,43 +787,48 @@ packages:
   permission_handler:
     dependency: "direct main"
     description:
-      name: permission_handler
-      sha256: bc56bfe9d3f44c3c612d8d393bd9b174eb796d706759f9b495ac254e4294baa5
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.4.5"
+      path: permission_handler
+      ref: master
+      resolved-ref: "5f9cd3a698dd64975f68a36c581a1097bc47563c"
+      url: "https://github.com/bvoq/flutter-permission-handler.git"
+    source: git
+    version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
-      name: permission_handler_android
-      sha256: "59c6322171c29df93a22d150ad95f3aa19ed86542eaec409ab2691b8f35f9a47"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.3.6"
+      path: permission_handler_android
+      ref: master
+      resolved-ref: "5f9cd3a698dd64975f68a36c581a1097bc47563c"
+      url: "https://github.com/bvoq/flutter-permission-handler.git"
+    source: git
+    version: "10.2.0"
   permission_handler_apple:
     dependency: transitive
     description:
-      name: permission_handler_apple
-      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.4"
+      path: permission_handler_apple
+      ref: master
+      resolved-ref: "5f9cd3a698dd64975f68a36c581a1097bc47563c"
+      url: "https://github.com/bvoq/flutter-permission-handler.git"
+    source: git
+    version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
-      name: permission_handler_platform_interface
-      sha256: "6760eb5ef34589224771010805bea6054ad28453906936f843a8cc4d3a55c4a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.12.0"
+      path: permission_handler_platform_interface
+      ref: master
+      resolved-ref: "5f9cd3a698dd64975f68a36c581a1097bc47563c"
+      url: "https://github.com/bvoq/flutter-permission-handler.git"
+    source: git
+    version: "3.9.0"
   permission_handler_windows:
     dependency: transitive
     description:
-      name: permission_handler_windows
-      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
+      path: permission_handler_windows
+      ref: master
+      resolved-ref: "5f9cd3a698dd64975f68a36c581a1097bc47563c"
+      url: "https://github.com/bvoq/flutter-permission-handler.git"
+    source: git
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
@@ -1261,14 +1242,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,12 +38,12 @@ dependencies:
   loggy: ^2.0.1+1
   package_info_plus: ^4.0.2
   pem: ^2.0.1
-  permission_handler: ^10.2.0
-  # permission_handler:
-  #   git:
-  #     url: https://github.com/bvoq/flutter-permission-handler.git
-  #     path: permission_handler
-  #     ref: master
+  # permission_handler: ^10.2.0
+  permission_handler:
+    git:
+      url: https://github.com/bvoq/flutter-permission-handler.git
+      path: permission_handler
+      ref: master
   shared_preferences: ^2.2.2
   shared_preferences_web: ^2.0.3
   sizer: ^2.0.15


### PR DESCRIPTION
# Description

This PR addresses the issue of encountering a MissingPluginException during macOS installation, specifically related to the checkPermissionStatus method. The issue is resolved by incorporating the following changes:

- Modified pubspec.yaml to use permission_handler directly from its GitHub repository.
- Added registration of the PathProviderPlugin in the GeneratedPluginRegistrant.swift file.

## Fixes #335 

## Screenshots
The app is now successfully rendering on macOS: 
<img width="1000" alt="Screenshot 2024-03-15 at 1 45 55 AM" src="https://github.com/CCExtractor/taskwarrior-flutter/assets/83498152/6784b2b1-121e-4999-887f-69e3c94f47c6">

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing