### PR TITLE
Fixed double tap to exit app 

### DIFF
--- a/lib/app/modules/home/views/home_page_body.dart
+++ b/lib/app/modules/home/views/home_page_body.dart
@@ -20,7 +20,6 @@ class HomePageBody extends StatelessWidget {
     controller.showInAppTour(context);
     return DoubleBackToCloseApp(
       snackBar: const SnackBar(content: Text('Tap back again to exit')),
-      // ignore: avoid_unnecessary_containers
       child: Container(
         color: AppSettings.isDarkMode
             ? Palette.kToDark.shade200

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -33,12 +33,6 @@ class HomeView extends GetView<HomeController> {
 
     controller.checkForSync(context);
 
-    // var taskData = controller.searchedTasks;
-
-    // var pendingFilter = controller.pendingFilter;
-    // var waitingFilter = controller.waitingFilter;
-    // var pendingTags = controller.pendingTags;
-
     return Obx(
       () => Scaffold(
         appBar: HomePageAppBar(

--- a/lib/app/modules/onboarding/views/onboarding_page_start_button.dart
+++ b/lib/app/modules/onboarding/views/onboarding_page_start_button.dart
@@ -16,11 +16,7 @@ class OnboardingPageStartButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: () {
           controller.markOnboardingAsCompleted();
-          // Navigator.of(context).pushAndRemoveUntil(
-          //   MaterialPageRoute(builder: (context) => const HomeView()),
-          //   (Route<dynamic> route) => false,
-          // );
-          Get.toNamed(Routes.HOME);
+          Get.offNamed(Routes.HOME);
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: TaskWarriorColors.black,

--- a/lib/app/modules/splash/bindings/splash_binding.dart
+++ b/lib/app/modules/splash/bindings/splash_binding.dart
@@ -7,6 +7,7 @@ class SplashBinding extends Bindings {
   void dependencies() {
     Get.put<SplashController>(
       SplashController(),
+      permanent: true,
     );
   }
 }

--- a/lib/app/modules/splash/controllers/splash_controller.dart
+++ b/lib/app/modules/splash/controllers/splash_controller.dart
@@ -95,9 +95,9 @@ class SplashController extends GetxController {
   void sendToNextPage() async {
     await checkOnboardingStatus();
     if (hasCompletedOnboarding.value) {
-      Get.toNamed(Routes.HOME);
+      Get.offNamed(Routes.HOME);
     } else {
-      Get.toNamed(Routes.ONBOARDING);
+      Get.offNamed(Routes.ONBOARDING);
     }
   }
 }


### PR DESCRIPTION


# Description

Fixed double tap to exit app bug by removing onboarding screen and splash screen from navigation stack using Get.off

## Fixes #(issue_no)

#355 

## Screenshots

https://github.com/CCExtractor/taskwarrior-flutter/assets/111864031/aa54f487-947f-4fcb-90bb-108e79a3f20f




## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [X] Code follows the established coding style guidelines
- [ ] All tests are passing