### PR TITLE
feat: added toasts for server errors

### DIFF
--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -2,6 +2,7 @@
 
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
@@ -205,6 +206,11 @@ Future<void> completeTask(String email, String taskUuid) async {
       debugPrint('Task completed successfully on server');
     } else {
       debugPrint('Failed to complete task: ${response.statusCode}');
+      ScaffoldMessenger.of(context as BuildContext).showSnackBar(const SnackBar(
+          content: Text(
+        "Failed to complete task!",
+        style: TextStyle(color: Colors.red),
+      )));
     }
   } catch (e) {
     debugPrint('Error completing task: $e');
@@ -250,7 +256,7 @@ Future<void> modifyTaskOnTaskwarrior(String description, String project,
   var e = await CredentialsStorage.getEncryptionSecret();
   debugPrint(c);
   debugPrint(e);
-  await http.post(
+  final response = await http.post(
     Uri.parse(apiUrl),
     headers: {
       'Content-Type': 'text/plain',
@@ -267,6 +273,14 @@ Future<void> modifyTaskOnTaskwarrior(String description, String project,
       "taskuuid": taskuuid,
     }),
   );
+
+  if (response.statusCode != 200) {
+    ScaffoldMessenger.of(context as BuildContext).showSnackBar(const SnackBar(
+        content: Text(
+      "Failed to update task!",
+      style: TextStyle(color: Colors.red),
+    )));
+  }
 
   var taskDatabase = TaskDatabase();
   await taskDatabase.open();


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Fixes #369

## Screenshots
![Screenshot from 2024-11-14 23-49-22](https://github.com/user-attachments/assets/9e928994-ab7a-4fab-83b6-30ff6123be49)

video demo:
https://github.com/user-attachments/assets/b2b04c28-8f84-4d88-b8c5-b259fcf15fee


<!-- If applicable, add screenshots or images demonstrating the changes made -->
## Summary
added toasts in case the `http.post` request fails in the `lib/api_service.dart` file. total changes in 2 functions: 
`completeTask` and `modifyTaskOnTaskwarrior` to add error toast for better user understanding.

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing