### PR TITLE
feat: Improve tags add ux while adding task

### DIFF
--- a/lib/app/modules/home/views/add_task_bottom_sheet.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet.dart
@@ -112,6 +112,13 @@ class AddTaskBottomSheet extends StatelessWidget {
                 onFieldSubmitted: (tag) {
                   addTag(tag.trim());
                 },
+                onChanged: (value) {
+                  String trimmedString = value.trim();
+                  if (value.endsWith(" ") &&
+                      trimmedString.split(' ').length == 1) {
+                    addTag(trimmedString);
+                  }
+                },
               ),
             ),
             IconButton(
@@ -158,9 +165,9 @@ class AddTaskBottomSheet extends StatelessWidget {
         ),
         validator: (name) => name != null && name.isEmpty
             ? SentenceManager(
-                        currentLanguage: homeController.selectedLanguage.value)
-                    .sentences
-                    .addTaskFieldCannotBeEmpty
+                    currentLanguage: homeController.selectedLanguage.value)
+                .sentences
+                .addTaskFieldCannotBeEmpty
             : null,
       );
 
@@ -400,9 +407,9 @@ class AddTaskBottomSheet extends StatelessWidget {
       TextButton(
         child: Text(
           SentenceManager(
-                        currentLanguage: homeController.selectedLanguage.value)
-                    .sentences
-                    .addTaskCancel,
+                  currentLanguage: homeController.selectedLanguage.value)
+              .sentences
+              .addTaskCancel,
           style: TextStyle(
             color: AppSettings.isDarkMode
                 ? TaskWarriorColors.white
@@ -425,8 +432,8 @@ class AddTaskBottomSheet extends StatelessWidget {
       child: Text(
         SentenceManager(
                         currentLanguage: homeController.selectedLanguage.value)
-                    .sentences
-                    .addTaskAdd,
+            .sentences
+            .addTaskAdd,
         style: TextStyle(
           color: AppSettings.isDarkMode
               ? TaskWarriorColors.white
@@ -472,8 +479,8 @@ class AddTaskBottomSheet extends StatelessWidget {
                 content: Text(
                   SentenceManager(
                         currentLanguage: homeController.selectedLanguage.value)
-                    .sentences
-                    .addTaskTaskAddedSuccessfully,
+                      .sentences
+                      .addTaskTaskAddedSuccessfully,
                   style: TextStyle(
                     color: AppSettings.isDarkMode
                         ? TaskWarriorColors.kprimaryTextColor

--- a/lib/app/modules/home/views/add_task_bottom_sheet.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: use_build_context_synchronously
 import 'dart:developer';
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/app/modules/home/views/add_task_bottom_sheet.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet.dart
@@ -526,7 +526,9 @@ class AddTaskBottomSheet extends StatelessWidget {
   void addTag(String tag) {
     if (tag.isNotEmpty) {
       String trimmedString = tag.trim();
-      homeController.tags.add(trimmedString);
+      trimmedString.split(" ").forEach((v) {
+        homeController.tags.add(v);
+      });
       homeController.tagcontroller.text = '';
     }
   }

--- a/lib/app/modules/home/views/add_task_bottom_sheet.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
 import 'dart:developer';
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -526,13 +527,19 @@ class AddTaskBottomSheet extends StatelessWidget {
   void addTag(String tag) {
     if (tag.isNotEmpty) {
       String trimmedString = tag.trim();
-      trimmedString.split(" ").forEach((v) {
-        homeController.tags.add(v);
-      });
+      List<String> tags = trimmedString.split(" ");
+      for(tag in tags){
+        if(checkTagIfExists(tag)) {
+          removeTag(tag);
+        }
+        homeController.tags.add(tag);
+      }
       homeController.tagcontroller.text = '';
     }
   }
-
+  bool checkTagIfExists(String tag){
+    return homeController.tags.contains(tag);
+  }
   void removeTag(String tag) {
     homeController.tags.remove(tag);
   }


### PR DESCRIPTION
# Description

This PR improves the way tags can be added while adding tasks
1. on inputing whitespace tag gets added
2. if input has space in between, it adds the tags by splitting with whitespace
3. also if tags are being repeated it'll delete the tag which was added previously and add again to show that it's added now


## Fixes #398 
> After adding tags which has whitespace in between are not valid as per guidelines so after clicking on add task it shows an error snackbar.
> It should be changed so that user will not have to delete tags and add differently without space.


## Screenshots

https://github.com/user-attachments/assets/82dda543-6565-42c7-bc96-e00517b5d80e

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
