### PR TITLE
fix: datepicker error fixed

### DIFF
--- a/lib/app/modules/home/views/add_task_bottom_sheet.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet.dart
@@ -250,7 +250,7 @@ class AddTaskBottomSheet extends StatelessWidget {
                     },
                     fieldHintText: "Month/Date/Year",
                     context: context,
-                    initialDate: homeController.due.value ?? DateTime.now(),
+                    initialDate: homeController.due.value?? DateTime.now(),
                     firstDate: DateTime.now(),
                     lastDate: DateTime(2037, 12, 31),
                   );
@@ -305,7 +305,7 @@ class AddTaskBottomSheet extends StatelessWidget {
                         ),
                       );
                       // print(dateTime);
-                      homeController.due.value = dateTime.toUtc();
+                      homeController.due.value = dateTime;
 
                       // print("due value ${homeController.due}");
                       homeController.dueString.value =
@@ -442,10 +442,31 @@ class AddTaskBottomSheet extends StatelessWidget {
       ),
       onPressed: () async {
         // print(homeController.formKey.currentState);
+        if(homeController.due.value!=null&&DateTime.now().isAfter(homeController.due.value!)){
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: Text(
+                SentenceManager(
+                    currentLanguage:
+                    homeController.selectedLanguage.value)
+                    .sentences
+                    .addTaskTimeInPast,
+                style: TextStyle(
+                  color: AppSettings.isDarkMode
+                      ? TaskWarriorColors.kprimaryTextColor
+                      : TaskWarriorColors.kLightPrimaryTextColor,
+                ),
+              ),
+              backgroundColor: AppSettings.isDarkMode
+                  ? TaskWarriorColors.ksecondaryBackgroundColor
+                  : TaskWarriorColors
+                  .kLightSecondaryBackgroundColor,
+              duration: const Duration(seconds: 2)));
+          return;
+        }
         if (homeController.formKey.currentState!.validate()) {
           try {
             var task = taskParser(homeController.namecontroller.text)
-                .rebuild((b) => b..due = homeController.due.value)
+                .rebuild((b) => b..due = homeController.due.value?.toUtc())
                 .rebuild((p) => p..priority = homeController.priority.value);
             if (homeController.tagcontroller.text != "") {
               homeController.tags.add(homeController.tagcontroller.text.trim());
@@ -462,6 +483,7 @@ class AddTaskBottomSheet extends StatelessWidget {
             homeController.priority.value = 'M';
             homeController.tagcontroller.text = '';
             homeController.tags.value = [];
+            homeController.due.value=null;
             homeController.update();
             // Navigator.of(context).pop();
             Get.back();


### PR DESCRIPTION
# Description

The time in addtask was being stored as UTC Time and datepicker using it as datetime(local) which was letting date to go in past. Which occured assertion error when date picker was being shown again. because date was in past and first date was todays.

## Fixes #422 

Additionally Disabled adding task if time selected is in past 
## Screenshots

https://github.com/user-attachments/assets/4fd2125e-1def-4600-9daa-4bc1ca4833ec

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing