### PR TITLE
fix: deleting profile will refresh current profile storage and tasks

### DIFF
--- a/lib/app/modules/profile/views/deleteprofiledialog.dart
+++ b/lib/app/modules/profile/views/deleteprofiledialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:taskwarrior/app/modules/home/controllers/home_controller.dart';
 import 'package:taskwarrior/app/modules/splash/controllers/splash_controller.dart';
 import 'package:taskwarrior/app/utils/constants/taskwarrior_colors.dart';
 import 'package:taskwarrior/app/utils/constants/utilites.dart';
@@ -55,6 +56,7 @@ class DeleteProfileDialog extends StatelessWidget {
                   try {
                     Get.find<SplashController>().deleteProfile(profile);
                     // Navigator.of(context).pop();
+                    Get.find<HomeController>().refreshTaskWithNewProfile();
                     Get.back();
                     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: Text(


### PR DESCRIPTION

# Description

After deletionprofile,  tasks and storage directory was not being synced. Fixes: #423

This has been fixed by adding `Get.find<HomeController>().refreshTaskWithNewProfile();` which syncs tasks and directory for current profile storage as suggested by @BrawlerXull 

## Fixes #423

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

https://github.com/user-attachments/assets/eb3f85b5-ac20-46dd-9537-fffb0e766def


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing