### PR TITLE
feat: added permission request screen

### DIFF
--- a/lib/app/modules/onboarding/views/onboarding_page_start_button.dart
+++ b/lib/app/modules/onboarding/views/onboarding_page_start_button.dart
@@ -16,7 +16,7 @@ class OnboardingPageStartButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: () {
           controller.markOnboardingAsCompleted();
-          Get.offNamed(Routes.HOME);
+          Get.offNamed(Routes.PERMISSION);
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: TaskWarriorColors.black,

--- a/lib/app/modules/permission/bindings/permission_binding.dart
+++ b/lib/app/modules/permission/bindings/permission_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/permission_controller.dart';
+
+class PermissionBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<PermissionController>(
+      () => PermissionController(),
+    );
+  }
+}

--- a/lib/app/modules/permission/controllers/permission_controller.dart
+++ b/lib/app/modules/permission/controllers/permission_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -18,7 +19,7 @@ class PermissionController extends GetxController {
       isNotificationGranted.value =
           await Permission.notification.status.isGranted;
     } catch (e) {
-      print('Error checking permissions: $e');
+      debugPrint('Error checking permissions: $e');
     }
   }
 
@@ -41,7 +42,7 @@ class PermissionController extends GetxController {
         Get.offNamed('/home');
       }
     } catch (e) {
-      print('Error requesting permissions: $e');
+      debugPrint('Error requesting permissions: $e');
     } finally {
       isLoading.value = false;
     }
@@ -51,7 +52,7 @@ class PermissionController extends GetxController {
     try {
       await Get.offNamed('/home');
     } catch (e) {
-      print('Error opening settings: $e');
+      debugPrint('Error opening home screen: $e');
     }
   }
 }

--- a/lib/app/modules/permission/controllers/permission_controller.dart
+++ b/lib/app/modules/permission/controllers/permission_controller.dart
@@ -1,0 +1,57 @@
+import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class PermissionController extends GetxController {
+  final RxBool isStorageGranted = false.obs;
+  final RxBool isNotificationGranted = false.obs;
+  final RxBool isLoading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    checkPermissions();
+  }
+
+  Future<void> checkPermissions() async {
+    try {
+      isStorageGranted.value = await Permission.storage.status.isGranted;
+      isNotificationGranted.value =
+          await Permission.notification.status.isGranted;
+    } catch (e) {
+      print('Error checking permissions: $e');
+    }
+  }
+
+  Future<void> requestPermissions() async {
+    try {
+      isLoading.value = true;
+
+      PermissionStatus storageStatus;
+      if (GetPlatform.isAndroid) {
+        storageStatus = await Permission.storage.request();
+      } else {
+        storageStatus = await Permission.photos.request();
+      }
+      isStorageGranted.value = storageStatus.isGranted;
+
+      final notificationStatus = await Permission.notification.request();
+      isNotificationGranted.value = notificationStatus.isGranted;
+
+      if (isStorageGranted.value && isNotificationGranted.value) {
+        Get.offNamed('/home');
+      }
+    } catch (e) {
+      print('Error requesting permissions: $e');
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  void openSettings() async {
+    try {
+      await Get.offNamed('/home');
+    } catch (e) {
+      print('Error opening settings: $e');
+    }
+  }
+}

--- a/lib/app/modules/permission/views/permission_section.dart
+++ b/lib/app/modules/permission/views/permission_section.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:taskwarrior/app/utils/constants/taskwarrior_colors.dart';
+
+class PermissionSection extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String description;
+  final bool isDarkMode;
+
+  const PermissionSection({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.isDarkMode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: isDarkMode
+              ? TaskWarriorColors.ksecondaryBackgroundColor
+              : TaskWarriorColors.borderColor,
+        ),
+        borderRadius: BorderRadius.circular(12),
+        color: isDarkMode
+            ? TaskWarriorColors.kdialogBackGroundColor
+            : TaskWarriorColors.kLightDialogBackGroundColor,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: TaskWarriorColors.black),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: isDarkMode
+                            ? TaskWarriorColors.kprimaryTextColor
+                            : TaskWarriorColors.kLightPrimaryTextColor,
+                      ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: isDarkMode
+                      ? TaskWarriorColors.ksecondaryTextColor
+                      : TaskWarriorColors.kLightSecondaryTextColor,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/permission/views/permission_view.dart
+++ b/lib/app/modules/permission/views/permission_view.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
+import 'package:taskwarrior/app/utils/constants/taskwarrior_colors.dart';
+import '../controllers/permission_controller.dart';
+
+class PermissionView extends GetView<PermissionController> {
+  const PermissionView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
+    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Get.offAllNamed('/home');
+      });
+      return const SizedBox.shrink();
+    }
+
+    return Scaffold(
+      backgroundColor: isDarkMode
+          ? TaskWarriorColors.kprimaryBackgroundColor
+          : TaskWarriorColors.kLightPrimaryBackgroundColor,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 24),
+                Text(
+                  'Why We Need Your Permission',
+                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: isDarkMode
+                            ? TaskWarriorColors.kprimaryTextColor
+                            : TaskWarriorColors.kLightPrimaryTextColor,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                Icon(
+                  Icons.security,
+                  size: 64,
+                  color: AppSettings.isDarkMode
+                      ? TaskWarriorColors.black
+                      : TaskWarriorColors.white,
+                ),
+                const SizedBox(height: 32),
+                _buildPermissionSection(
+                  context,
+                  icon: Icons.folder_outlined,
+                  title: 'Storage Permission',
+                  description:
+                      'We use storage access to save your tasks, preferences, '
+                      'and app data securely on your device. This ensures that you can '
+                      'pick up where you left off seamlessly, even offline.',
+                  isDarkMode: isDarkMode,
+                ),
+                const SizedBox(height: 24),
+                _buildPermissionSection(
+                  context,
+                  icon: Icons.notifications_outlined,
+                  title: 'Notification Permission',
+                  description:
+                      'Notifications keep you updated with important reminders '
+                      'and updates, ensuring you stay on top of your tasks effortlessly.',
+                  isDarkMode: isDarkMode,
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Your privacy is our top priority. We never access or share your '
+                  'personal files or data without your consent.',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: AppSettings.isDarkMode
+                            ? TaskWarriorColors.black
+                            : TaskWarriorColors.white,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 48),
+                Obx(() => ElevatedButton(
+                      onPressed: controller.isLoading.value
+                          ? null
+                          : controller.requestPermissions,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.all(16),
+                        backgroundColor: AppSettings.isDarkMode
+                            ? TaskWarriorColors.black
+                            : TaskWarriorColors.white,
+                        foregroundColor: AppSettings.isDarkMode
+                            ? TaskWarriorColors.kprimaryTextColor
+                            : TaskWarriorColors.kLightPrimaryTextColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: controller.isLoading.value
+                          ? CircularProgressIndicator(
+                              color: AppSettings.isDarkMode
+                                  ? TaskWarriorColors.black
+                                  : TaskWarriorColors.white,
+                            )
+                          : Text(
+                              'Grant Permissions',
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.kprimaryTextColor
+                                    : TaskWarriorColors.kLightPrimaryTextColor,
+                                fontSize: 16,
+                              ),
+                            ),
+                    )),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () => controller.openSettings(),
+                  style: ButtonStyle(
+                    backgroundColor:
+                        WidgetStateProperty.all(TaskWarriorColors.grey),
+                  ),
+                  child: Text(
+                    'You can manage your permissions anytime later in Settings',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: AppSettings.isDarkMode
+                              ? TaskWarriorColors.black
+                              : TaskWarriorColors.white,
+                        ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPermissionSection(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String description,
+    required bool isDarkMode,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: isDarkMode
+              ? TaskWarriorColors.ksecondaryBackgroundColor
+              : TaskWarriorColors.borderColor,
+        ),
+        borderRadius: BorderRadius.circular(12),
+        color: isDarkMode
+            ? TaskWarriorColors.kdialogBackGroundColor
+            : TaskWarriorColors.kLightDialogBackGroundColor,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: TaskWarriorColors.black),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: isDarkMode
+                            ? TaskWarriorColors.kprimaryTextColor
+                            : TaskWarriorColors.kLightPrimaryTextColor,
+                      ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: isDarkMode
+                      ? TaskWarriorColors.ksecondaryTextColor
+                      : TaskWarriorColors.kLightSecondaryTextColor,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/permission/views/permission_view.dart
+++ b/lib/app/modules/permission/views/permission_view.dart
@@ -117,7 +117,7 @@ class PermissionView extends GetView<PermissionController> {
                     )),
                 const SizedBox(height: 16),
                 TextButton(
-                  onPressed: () => controller.openSettings(),
+                  onPressed: () => controller.gotoHome(),
                   style: ButtonStyle(
                     backgroundColor:
                         WidgetStateProperty.all(TaskWarriorColors.grey),

--- a/lib/app/modules/permission/views/permission_view.dart
+++ b/lib/app/modules/permission/views/permission_view.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:taskwarrior/app/modules/permission/views/permission_section.dart';
 import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 import 'package:taskwarrior/app/utils/constants/taskwarrior_colors.dart';
 import '../controllers/permission_controller.dart';
@@ -51,8 +52,7 @@ class PermissionView extends GetView<PermissionController> {
                       : TaskWarriorColors.white,
                 ),
                 const SizedBox(height: 32),
-                _buildPermissionSection(
-                  context,
+                PermissionSection(
                   icon: Icons.folder_outlined,
                   title: 'Storage Permission',
                   description:
@@ -62,8 +62,7 @@ class PermissionView extends GetView<PermissionController> {
                   isDarkMode: isDarkMode,
                 ),
                 const SizedBox(height: 24),
-                _buildPermissionSection(
-                  context,
+                PermissionSection(
                   icon: Icons.notifications_outlined,
                   title: 'Notification Permission',
                   description:
@@ -137,60 +136,6 @@ class PermissionView extends GetView<PermissionController> {
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildPermissionSection(
-    BuildContext context, {
-    required IconData icon,
-    required String title,
-    required String description,
-    required bool isDarkMode,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: isDarkMode
-              ? TaskWarriorColors.ksecondaryBackgroundColor
-              : TaskWarriorColors.borderColor,
-        ),
-        borderRadius: BorderRadius.circular(12),
-        color: isDarkMode
-            ? TaskWarriorColors.kdialogBackGroundColor
-            : TaskWarriorColors.kLightDialogBackGroundColor,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(icon, color: TaskWarriorColors.black),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: isDarkMode
-                            ? TaskWarriorColors.kprimaryTextColor
-                            : TaskWarriorColors.kLightPrimaryTextColor,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Text(
-            description,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: isDarkMode
-                      ? TaskWarriorColors.ksecondaryTextColor
-                      : TaskWarriorColors.kLightSecondaryTextColor,
-                ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -13,6 +13,8 @@ import '../modules/manageTaskServer/bindings/manage_task_server_binding.dart';
 import '../modules/manageTaskServer/views/manage_task_server_view.dart';
 import '../modules/onboarding/bindings/onboarding_binding.dart';
 import '../modules/onboarding/views/onboarding_view.dart';
+import '../modules/permission/bindings/permission_binding.dart';
+import '../modules/permission/views/permission_view.dart';
 import '../modules/profile/bindings/profile_binding.dart';
 import '../modules/profile/views/profile_view.dart';
 import '../modules/reports/bindings/reports_binding.dart';
@@ -74,6 +76,11 @@ class AppPages {
       name: _Paths.SETTINGS,
       page: () => const SettingsView(),
       binding: SettingsBinding(),
+    ),
+    GetPage(
+      name: _Paths.PERMISSION,
+      page: () => const PermissionView(),
+      binding: PermissionBinding(),
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -14,6 +14,7 @@ abstract class Routes {
   static const ABOUT = _Paths.ABOUT;
   static const REPORTS = _Paths.REPORTS;
   static const SETTINGS = _Paths.SETTINGS;
+  static const PERMISSION = _Paths.PERMISSION;
 }
 
 abstract class _Paths {
@@ -27,4 +28,5 @@ abstract class _Paths {
   static const ABOUT = '/about';
   static const REPORTS = '/reports';
   static const SETTINGS = '/settings';
+  static const PERMISSION = '/permission';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
-import 'package:taskwarrior/app/utils/permissions/permissions_manager.dart';
 import 'app/routes/app_pages.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await AppSettings.init();
-
-  await PermissionsManager.requestAllPermissions();
-
 
   runApp(
     GetMaterialApp(

--- a/test/routes/app_pages_test.dart
+++ b/test/routes/app_pages_test.dart
@@ -30,7 +30,7 @@ void main() {
     test('All routes should be defined correctly', () {
       final routes = AppPages.routes;
 
-      expect(routes.length, 9);
+      expect(routes.length, 10);
 
       expect(
         routes.any((route) =>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Fixes #412 

- Edited total of 4 files and added 3 files
- added new permissions page under `lib/app/models` folder using `get-cli` and edited accordingly
- edited files under `routes` folder to add the permission screen path
- modifies the `main.dart` file so that permissions are not requested at the app start.

* For Linux, Mac and Windows the screen is skipped using:
```dart
    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
      WidgetsBinding.instance.addPostFrameCallback((_) {
        Get.offAllNamed('/home');
      });
      return const SizedBox.shrink();
    }
``` 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots
Example in linux device:

[Screencast from 2025-01-13 00-07-04.webm](https://github.com/user-attachments/assets/3550c9c9-92dd-4ae0-b8fa-2962c2839f05)

Example in android device:

https://github.com/user-attachments/assets/1f5d30b8-87b5-4181-aec8-ff66c9c337e6

Final UI:

![WhatsApp Image 2025-01-12 at 10 38 46 PM (1)](https://github.com/user-attachments/assets/9ce646b4-d236-4810-87c1-e6b0f4f275aa)

![WhatsApp Image 2025-01-12 at 10 42 09 PM](https://github.com/user-attachments/assets/a0c6d1dc-6020-426a-98e8-ee9d8458bccb)


<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing