### PR TITLE
feat: added loading state to refresh tasks

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -56,6 +56,7 @@ class HomeController extends GetxController {
   final RxBool showbtn = false.obs;
   late TaskDatabase taskdb;
   var tasks = <Tasks>[].obs;
+  final RxBool isRefreshing = false.obs;
 
   @override
   void onInit() {
@@ -78,7 +79,7 @@ class HomeController extends GetxController {
       handleHomeWidgetClicked();
     }
     fetchTasksFromDB();
-        everAll([
+    everAll([
       pendingFilter,
       waitingFilter,
       projectFilter,
@@ -86,13 +87,12 @@ class HomeController extends GetxController {
       selectedSort,
       selectedTags,
     ], (_) {
-        if (Platform.isAndroid) {
-          WidgetController widgetController =
-              Get.put(WidgetController());
-          widgetController.fetchAllData();
+      if (Platform.isAndroid) {
+        WidgetController widgetController = Get.put(WidgetController());
+        widgetController.fetchAllData();
 
-          widgetController.update();
-        }
+        widgetController.update();
+      }
     });
   }
 
@@ -508,15 +508,12 @@ class HomeController extends GetxController {
   final projectcontroller = TextEditingController();
   var due = Rxn<DateTime>();
   RxString dueString = ''.obs;
-  final priorityList = ['L','X','M','H'];
+  final priorityList = ['L', 'X', 'M', 'H'];
   final priorityColors = [
     TaskWarriorColors.green,
     TaskWarriorColors.grey,
     TaskWarriorColors.yellow,
     TaskWarriorColors.red,
-
-
-
   ];
   RxString priority = 'X'.obs;
 
@@ -582,10 +579,9 @@ class HomeController extends GetxController {
   void initLanguageAndDarkMode() {
     isDarkModeOn.value = AppSettings.isDarkMode;
     selectedLanguage.value = AppSettings.selectedLanguage;
-    HomeWidget.saveWidgetData("themeMode", AppSettings.isDarkMode ? "dark" : "light");
-    HomeWidget.updateWidget(
-      androidName: "TaskWarriorWidgetProvider"
-    );
+    HomeWidget.saveWidgetData(
+        "themeMode", AppSettings.isDarkMode ? "dark" : "light");
+    HomeWidget.updateWidget(androidName: "TaskWarriorWidgetProvider");
     // print("called and value is${isDarkModeOn.value}");
   }
 
@@ -679,6 +675,7 @@ class HomeController extends GetxController {
       },
     );
   }
+
   late RxString uuid = "".obs;
   late RxBool isHomeWidgetTaskTapped = false.obs;
 
@@ -693,7 +690,7 @@ class HomeController extends GetxController {
             Get.toNamed(Routes.DETAIL_ROUTE, arguments: ["uuid", uuid.value]);
           });
         }
-      }else if(uri.host == "addclicked"){
+      } else if (uri.host == "addclicked") {
         showAddDialogAfterWidgetClick();
       }
     }
@@ -706,15 +703,17 @@ class HomeController extends GetxController {
           }
           debugPrint('uuid is $uuid');
           Get.toNamed(Routes.DETAIL_ROUTE, arguments: ["uuid", uuid.value]);
-        }else if(uri.host == "addclicked"){
+        } else if (uri.host == "addclicked") {
           showAddDialogAfterWidgetClick();
         }
       }
-      
     });
   }
+
   void showAddDialogAfterWidgetClick() {
-    Widget showDialog = taskchampion.value ? AddTaskToTaskcBottomSheet(homeController: this) : AddTaskBottomSheet(homeController: this);
+    Widget showDialog = taskchampion.value
+        ? AddTaskToTaskcBottomSheet(homeController: this)
+        : AddTaskBottomSheet(homeController: this);
     Get.dialog(showDialog);
   }
 }

--- a/lib/app/modules/home/views/home_page_app_bar.dart
+++ b/lib/app/modules/home/views/home_page_app_bar.dart
@@ -24,6 +24,78 @@ class HomePageAppBar extends StatelessWidget implements PreferredSizeWidget {
       required this.controller,
       super.key});
 
+  void _showLoadingSnackBar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        duration: const Duration(days: 1),
+        backgroundColor: AppSettings.isDarkMode
+            ? TaskWarriorColors.ksecondaryBackgroundColor
+            : TaskWarriorColors.kLightSecondaryBackgroundColor,
+        content: Row(
+          children: [
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: AppSettings.isDarkMode
+                    ? TaskWarriorColors.white
+                    : TaskWarriorColors.black,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Text(
+              message,
+              style: TextStyle(
+                color: AppSettings.isDarkMode
+                    ? TaskWarriorColors.white
+                    : TaskWarriorColors.black,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showResultSnackBar(BuildContext context, String message, bool isError) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: AppSettings.isDarkMode
+            ? TaskWarriorColors.ksecondaryBackgroundColor
+            : TaskWarriorColors.kLightSecondaryBackgroundColor,
+        content: Text(
+          message,
+          style: TextStyle(
+            color: AppSettings.isDarkMode
+                ? TaskWarriorColors.white
+                : TaskWarriorColors.black,
+          ),
+        ),
+        action: isError
+            ? SnackBarAction(
+                label: SentenceManager(
+                        currentLanguage: controller.selectedLanguage.value)
+                    .sentences
+                    .homePageSetup,
+                onPressed: () {
+                  if (controller.taskchampion.value) {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => ManageTaskChampionCreds(),
+                        )).then((value) {});
+                  } else {
+                    Get.toNamed(Routes.MANAGE_TASK_SERVER);
+                  }
+                },
+                textColor: TaskWarriorColors.purple,
+              )
+            : null,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return AppBar(
@@ -55,140 +127,98 @@ class HomePageAppBar extends StatelessWidget implements PreferredSizeWidget {
           ),
         ),
         Builder(
-          builder: (context) => IconButton(
-            key: controller.refreshKey,
-            icon: Icon(Icons.refresh, color: TaskWarriorColors.white),
-            onPressed: () async {
-              if (controller.taskchampion.value) {
-                var c = await CredentialsStorage.getClientId();
-                var e = await CredentialsStorage.getEncryptionSecret();
-                if (c != null && e != null) {
-                  try {
-                    // List<Tasks> tasks = await fetchTasks(c, e);
-                    // print(
-                    //     '///////////////////////////////////////////////////////////');
-                    // print(tasks.toList());
-                    // await updateTasksInDatabase(tasks);
-                    // print('Tasks updated successfully');
-                    // controller.fetchTasksFromDB();
-                    controller.refreshTasks(c, e);
-                    // Navigator.pushReplacement(
-                    //     context,
-                    //     PageRouteBuilder(
-                    //       pageBuilder: (context, animation1, animation2) =>
-                    //           const HomeView(),
-                    //       transitionDuration: Duration.zero,
-                    //       reverseTransitionDuration: Duration.zero,
-                    //     ));
-                  } catch (e) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        backgroundColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.ksecondaryBackgroundColor
-                            : TaskWarriorColors.kLightSecondaryBackgroundColor,
-                        content: Text(
-                          SentenceManager(
-                                  currentLanguage:
-                                      controller.selectedLanguage.value)
-                              .sentences
-                              .homePageTaskWarriorNotConfigured,
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        action: SnackBarAction(
-                          label: SentenceManager(
-                                  currentLanguage:
-                                      controller.selectedLanguage.value)
-                              .sentences
-                              .homePageSetup,
-                          onPressed: () {
-                            Navigator.push(
+          builder: (context) => Obx(() => IconButton(
+                key: controller.refreshKey,
+                icon: Icon(Icons.refresh, color: TaskWarriorColors.white),
+                onPressed: controller.isRefreshing.value
+                    ? null
+                    : () async {
+                        if (controller.taskchampion.value) {
+                          var c = await CredentialsStorage.getClientId();
+                          var e =
+                              await CredentialsStorage.getEncryptionSecret();
+                          if (c != null && e != null) {
+                            try {
+                              controller.isRefreshing.value = true;
+                              _showLoadingSnackBar(
+                                  context,
+                                  SentenceManager(
+                                          currentLanguage:
+                                              controller.selectedLanguage.value)
+                                      .sentences
+                                      .homePageFetchingTasks);
+
+                              await controller.refreshTasks(c, e);
+
+                              ScaffoldMessenger.of(context)
+                                  .hideCurrentSnackBar();
+
+                              _showResultSnackBar(
+                                  context,
+                                  SentenceManager(
+                                          currentLanguage:
+                                              controller.selectedLanguage.value)
+                                      .sentences
+                                      .homePageFetchingTasks,
+                                  false);
+                            } catch (e) {
+                              ScaffoldMessenger.of(context)
+                                  .hideCurrentSnackBar();
+                              _showResultSnackBar(
+                                  context,
+                                  SentenceManager(
+                                          currentLanguage:
+                                              controller.selectedLanguage.value)
+                                      .sentences
+                                      .homePageTaskWarriorNotConfigured,
+                                  true);
+                            } finally {
+                              controller.isRefreshing.value = false;
+                            }
+                          } else if (c == null || e == null) {
+                            _showResultSnackBar(
                                 context,
-                                MaterialPageRoute(
-                                  builder: (_) => ManageTaskChampionCreds(),
-                                )).then((value) {});
-                          },
-                          textColor: TaskWarriorColors.purple,
-                        ),
-                      ),
-                    );
-                  }
-                } else if (c == null || e == null) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      backgroundColor: AppSettings.isDarkMode
-                          ? TaskWarriorColors.ksecondaryBackgroundColor
-                          : TaskWarriorColors.kLightSecondaryBackgroundColor,
-                      content: Text(
-                        SentenceManager(
-                                currentLanguage:
-                                    controller.selectedLanguage.value)
-                            .sentences
-                            .homePageTaskWarriorNotConfigured,
-                        style: TextStyle(
-                          color: AppSettings.isDarkMode
-                              ? TaskWarriorColors.white
-                              : TaskWarriorColors.black,
-                        ),
-                      ),
-                      action: SnackBarAction(
-                        label: SentenceManager(
-                                currentLanguage:
-                                    controller.selectedLanguage.value)
-                            .sentences
-                            .homePageSetup,
-                        onPressed: () {
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => ManageTaskChampionCreds(),
-                              )).then((value) {});
-                        },
-                        textColor: TaskWarriorColors.purple,
-                      ),
-                    ),
-                  );
-                }
-              } else {
-                if (server != null || credentials != null) {
-                  controller.synchronize(context, true);
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Obx(
-                        () => Text(
-                          SentenceManager(
-                                  currentLanguage:
-                                      controller.selectedLanguage.value)
-                              .sentences
-                              .homePageTaskWarriorNotConfigured,
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                      ),
-                      action: SnackBarAction(
-                        label: SentenceManager(
-                                currentLanguage:
-                                    controller.selectedLanguage.value)
-                            .sentences
-                            .homePageSetup,
-                        onPressed: () {
-                          Get.toNamed(Routes.MANAGE_TASK_SERVER);
-                        },
-                        textColor: TaskWarriorColors.purple,
-                      ),
-                    ),
-                  );
-                }
-              }
-            },
-          ),
+                                SentenceManager(
+                                        currentLanguage:
+                                            controller.selectedLanguage.value)
+                                    .sentences
+                                    .homePageTaskWarriorNotConfigured,
+                                true);
+                          }
+                        } else {
+                          if (server != null || credentials != null) {
+                            controller.isRefreshing.value = true;
+                            try {
+                              await controller.synchronize(context, true);
+                              ScaffoldMessenger.of(context)
+                                  .hideCurrentSnackBar();
+                            } catch (e) {
+                              ScaffoldMessenger.of(context)
+                                  .hideCurrentSnackBar();
+                              _showResultSnackBar(
+                                  context,
+                                  SentenceManager(
+                                          currentLanguage:
+                                              controller.selectedLanguage.value)
+                                      .sentences
+                                      .homePageTaskWarriorNotConfigured,
+                                  true);
+                            } finally {
+                              controller.isRefreshing.value = false;
+                            }
+                          } else {
+                            _showResultSnackBar(
+                                context,
+                                SentenceManager(
+                                        currentLanguage:
+                                            controller.selectedLanguage.value)
+                                    .sentences
+                                    .homePageTaskWarriorNotConfigured,
+                                true);
+                          }
+                        }
+                      },
+              )),
         ),
         Builder(
           builder: (context) => IconButton(

--- a/lib/app/utils/language/bengali_sentences.dart
+++ b/lib/app/utils/language/bengali_sentences.dart
@@ -32,6 +32,8 @@ class BengaliSentences extends Sentences {
   @override
   String get homePageSearchNotFound => 'অনুসন্ধানে কিছু পাওয়া যায়নি';
   @override
+  String get homePageFetchingTasks => 'টাস্ক আনা হচ্ছে';
+  @override
   String get settingsPageTitle => 'সেটিংস পেজ';
   @override
   String get settingsPageSubtitle => 'আপনার পছন্দ সেট করুন';

--- a/lib/app/utils/language/english_sentences.dart
+++ b/lib/app/utils/language/english_sentences.dart
@@ -32,6 +32,8 @@ class EnglishSentences extends Sentences {
       'Click on the bottom right button to start adding tasks';
   @override
   String get homePageSearchNotFound => 'Search Not Found';
+  @override
+  String get homePageFetchingTasks => 'Fetching Tasks';
 
   @override
   String get settingsPageTitle => 'Settings Page';

--- a/lib/app/utils/language/french_sentences.dart
+++ b/lib/app/utils/language/french_sentences.dart
@@ -32,6 +32,8 @@ class FrenchSentences extends Sentences {
   @override
   String get homePageSearchNotFound => 'Aucun résultat pour la recherche';
   @override
+  String get homePageFetchingTasks => 'Récupération de tâches';
+  @override
   String get settingsPageTitle => 'Page des paramètres';
   @override
   String get settingsPageSubtitle => 'Configurez vos préférences';

--- a/lib/app/utils/language/hindi_sentences.dart
+++ b/lib/app/utils/language/hindi_sentences.dart
@@ -32,6 +32,8 @@ class HindiSentences extends Sentences {
   @override
   String get homePageSearchNotFound => 'खोजने पर नहीं मिला';
   @override
+  String get homePageFetchingTasks => 'कार्य लाये जा रहे हैं';
+  @override
   String get settingsPageTitle => 'सेटिंग्स पेज';
   @override
   String get settingsPageSubtitle => 'अपनी पसंद सेट करें';

--- a/lib/app/utils/language/marathi_sentences.dart
+++ b/lib/app/utils/language/marathi_sentences.dart
@@ -32,6 +32,8 @@ class MarathiSentences extends Sentences {
   @override
   String get homePageSearchNotFound => 'शोध सापडला नाही';
   @override
+  String get homePageFetchingTasks => 'कार्ये आणत आहे';
+  @override
   String get settingsPageTitle => 'सेटिंग्स पेज';
   @override
   String get settingsPageSubtitle => 'तुमची पसंती सेट करा';

--- a/lib/app/utils/language/sentences.dart
+++ b/lib/app/utils/language/sentences.dart
@@ -14,6 +14,7 @@ abstract class Sentences {
   String get homePageCancel;
   String get homePageClickOnTheBottomRightButtonToStartAddingTasks;
   String get homePageSearchNotFound;
+  String get homePageFetchingTasks;
 
   String get settingsPageTitle;
   String get settingsPageSubtitle;
@@ -157,5 +158,4 @@ abstract class Sentences {
   String get aboutPageGitHubLink;
   String get aboutPageProjectDescription;
   String get aboutPageAppBarTitle;
-
 }

--- a/lib/app/utils/language/spanish_sentences.dart
+++ b/lib/app/utils/language/spanish_sentences.dart
@@ -33,6 +33,8 @@ class SpanishSentences extends Sentences {
   String get homePageSearchNotFound =>
       'No se encontraron resultados para la búsqueda';
   @override
+  String get homePageFetchingTasks => 'Obteniendo tareas';
+  @override
   String get settingsPageTitle => 'Página de configuración';
   @override
   String get settingsPageSubtitle => 'Configura tus preferencias';


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Fixes #433

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots
[Screencast from 2025-01-21 21-42-57.webm](https://github.com/user-attachments/assets/917267c6-6f68-4c64-9d66-6799daac9ddb)

## Summary
- updated `home_page_app_bar.dart` to include the loader logic
- updated the `home_page_controller.dart` to include `isRefreshing` boolean flag
- modified all language sentences to add the versions of English sentence`Fetching tasks`.

<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing