### PR TITLE
Migrated to v4 of artifact

### DIFF
--- a/.github/workflows/flutterci.yml
+++ b/.github/workflows/flutterci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: flutter build apk
       
       # Step 9: Upload the built APK as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: build/app/outputs/apk/release/app-release.apk


### PR DESCRIPTION
# Description
Flutter CI Failing is being fixed with this PR as artifact v3 has been deprecated from 30th Jan 2025 our flutter CI check was failing. 

Check these checks https://github.com/SGI-CAPP-AT2/fork-taskwarrior-flutter/actions/runs/13284776096/job/37090902680?pr=11

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing