### PR TITLE
fix: fixed page popped out of context during tutorial and details page bug

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
   - connectivity_plus (0.0.1):
     - Flutter
-    - ReachabilitySwift
   - DKImagePickerController/Core (4.3.4):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
@@ -43,9 +42,9 @@ PODS:
   - Flutter (1.0.0)
   - flutter_local_notifications (0.0.1):
     - Flutter
-  - flutter_native_splash (0.0.1):
+  - flutter_native_splash (2.4.3):
     - Flutter
-  - flutter_native_timezone (0.0.1):
+  - flutter_timezone (0.0.1):
     - Flutter
   - home_widget (0.0.1):
     - Flutter
@@ -54,13 +53,15 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - permission_handler_apple (9.0.4):
+  - permission_handler_apple (9.3.0):
     - Flutter
-  - ReachabilitySwift (5.0.0)
   - SDWebImage (5.19.0):
     - SDWebImage/Core (= 5.19.0)
   - SDWebImage/Core (5.19.0)
   - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
   - SwiftyGif (5.4.4)
@@ -75,19 +76,19 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
-  - flutter_native_timezone (from `.symlinks/plugins/flutter_native_timezone/ios`)
+  - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
-    - ReachabilitySwift
     - SDWebImage
     - SwiftyGif
 
@@ -106,8 +107,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
-  flutter_native_timezone:
-    :path: ".symlinks/plugins/flutter_native_timezone/ios"
+  flutter_timezone:
+    :path: ".symlinks/plugins/flutter_timezone/ios"
   home_widget:
     :path: ".symlinks/plugins/home_widget/ios"
   package_info_plus:
@@ -118,30 +119,32 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: 15fd9539e4eb735dc54bae8c0534a7a9511a03de
-  file_picker_writable: 67959f5c516feb5121693a14eda63fcbe6cbb6dc
-  file_selector_ios: 8c25d700d625e1dcdd6599f2d927072f2254647b
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker_writable: 3a458aa8cdb7c1378cb3e8ec0543ead87a77d0be
+  file_selector_ios: f92e583d43608aebc2e4a18daac30b8902845502
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
-  flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
-  flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
-  home_widget: 0434835a4c9a75704264feff6be17ea40e0f0d57
-  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
+  home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   SDWebImage: 981fd7e860af070920f249fd092420006014c3eb
-  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
-  url_launcher_ios: bbd758c6e7f9fd7b5b1d4cde34d2b95fcce5e812
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				E6257F2992FA3E40BE65E7BD /* [CP] Embed Pods Frameworks */,
+				8FEC10D1539C672E7E2B68F4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -235,6 +236,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		8FEC10D1539C672E7E2B68F4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
+++ b/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
@@ -15,6 +15,7 @@ class DetailRouteController extends GetxController {
   late String uuid;
   late Modify modify;
   var onEdit = false.obs;
+  var isTourActive = false.obs;
 
   @override
   void onInit() {
@@ -34,7 +35,7 @@ class DetailRouteController extends GetxController {
   void setAttribute(String name, dynamic newValue) {
     modify.set(name, newValue);
     onEdit.value = true;
-    if(name == 'start'){
+    if (name == 'start') {
       debugPrint('Start Value Changed to $newValue');
       startValue.value = newValue;
     }
@@ -44,13 +45,7 @@ class DetailRouteController extends GetxController {
   Future<void> saveChanges() async {
     var now = DateTime.now().toUtc();
     modify.save(modified: () => now);
-    onEdit.value = false;
-    Get.back();
-    Get.snackbar(
-      'Task Updated',
-      '',
-      snackPosition: SnackPosition.BOTTOM,
-    );
+    Get.back(result: true);
   }
 
   //  'description': controller.modify.draft.description,
@@ -118,6 +113,7 @@ class DetailRouteController extends GetxController {
       opacityShadow: 1.00,
       hideSkip: true,
       onFinish: () {
+        isTourActive.value = false;
         SaveTourStatus.saveDetailsTourStatus(true);
       },
     );
@@ -130,6 +126,7 @@ class DetailRouteController extends GetxController {
         SaveTourStatus.getDetailsTourStatus().then((value) => {
               if (value == false)
                 {
+                  isTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else

--- a/lib/app/modules/detailRoute/views/detail_route_view.dart
+++ b/lib/app/modules/detailRoute/views/detail_route_view.dart
@@ -22,80 +22,92 @@ class DetailRouteView extends GetView<DetailRouteController> {
   Widget build(BuildContext context) {
     controller.initDetailsPageTour();
     controller.showDetailsPageTour(context);
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) return;
+
+        if (controller.isTourActive.value) {
+          return;
+        }
+
         if (!controller.onEdit.value) {
           // Get.offAll(() => const HomeView());
           Get.back();
-          // Get.toNamed(Routes.HOME);
-          return false;
+          return;
         }
 
-        bool? save = await showDialog(
-          context: context,
-          builder: (context) {
-            return AlertDialog(
-              backgroundColor: AppSettings.isDarkMode
-                  ? TaskWarriorColors.kdialogBackGroundColor
-                  : TaskWarriorColors.kLightDialogBackGroundColor,
-              title: Text(
-                'Do you want to save changes?',
-                style: TextStyle(
-                  color: AppSettings.isDarkMode
-                      ? TaskWarriorColors.white
-                      : TaskWarriorColors.black,
+        bool? done = await Get.dialog(
+          AlertDialog(
+            backgroundColor: AppSettings.isDarkMode
+                ? TaskWarriorColors.kdialogBackGroundColor
+                : TaskWarriorColors.kLightDialogBackGroundColor,
+            title: Text(
+              'Do you want to save changes?',
+              style: TextStyle(
+                color: AppSettings.isDarkMode
+                    ? TaskWarriorColors.white
+                    : TaskWarriorColors.black,
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  controller.saveChanges();
+                },
+                child: Text(
+                  'Yes',
+                  style: TextStyle(
+                    color: AppSettings.isDarkMode
+                        ? TaskWarriorColors.white
+                        : TaskWarriorColors.black,
+                  ),
                 ),
               ),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    controller.saveChanges();
-                    // Get.offAll(() => const HomeView());
-
-                    Get.back();
-                  },
-                  child: Text(
-                    'Yes',
-                    style: TextStyle(
-                      color: AppSettings.isDarkMode
-                          ? TaskWarriorColors.white
-                          : TaskWarriorColors.black,
-                    ),
+              TextButton(
+                onPressed: () {
+                  Get.back(result: true);
+                  controller.onEdit.value = false;
+                },
+                child: Text(
+                  'No',
+                  style: TextStyle(
+                    color: AppSettings.isDarkMode
+                        ? TaskWarriorColors.white
+                        : TaskWarriorColors.black,
                   ),
                 ),
-                TextButton(
-                  onPressed: () {
-                    // Get.offAll(() => const HomeView());
-
-                    Get.back();
-                  },
-                  child: Text(
-                    'No',
-                    style: TextStyle(
-                      color: AppSettings.isDarkMode
-                          ? TaskWarriorColors.white
-                          : TaskWarriorColors.black,
-                    ),
+              ),
+              TextButton(
+                onPressed: () {
+                  Get.back(result: false);
+                },
+                child: Text(
+                  'Cancel',
+                  style: TextStyle(
+                    color: AppSettings.isDarkMode
+                        ? TaskWarriorColors.white
+                        : TaskWarriorColors.black,
                   ),
                 ),
-                TextButton(
-                  onPressed: () {
-                    Get.back();
-                  },
-                  child: Text(
-                    'Cancel',
-                    style: TextStyle(
-                      color: AppSettings.isDarkMode
-                          ? TaskWarriorColors.white
-                          : TaskWarriorColors.black,
-                    ),
-                  ),
-                ),
-              ],
-            );
-          },
+              ),
+            ],
+          ),
+          barrierDismissible: false,
         );
-        return save == true;
+        //runs when 'yes' or 'no' is clicked
+        if (done == true) {
+          Get.back();
+          // only runs when 'yes' is clicked
+          if (controller.onEdit.value==true) {
+            controller.onEdit.value = false;
+            Get.snackbar(
+              'Task Updated',
+              '',
+              snackPosition: SnackPosition.BOTTOM,
+            );
+          }
+        }
       },
       child: Scaffold(
           backgroundColor: AppSettings.isDarkMode
@@ -159,28 +171,40 @@ class DetailRouteView extends GetView<DetailRouteController> {
                       : TaskWarriorColors.white,
                   heroTag: "btn1",
                   onPressed: () {
-                    showDialog(
-                      context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          scrollable: true,
-                          title: Text(
-                            'Review changes:',
+                    Get.dialog(
+                      AlertDialog(
+                        scrollable: true,
+                        title: Text(
+                          'Review changes:',
+                          style: TextStyle(
+                            color: AppSettings.isDarkMode
+                                ? TaskWarriorColors.white
+                                : TaskWarriorColors.black,
+                          ),
+                        ),
+                        content: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Text(
+                            controller.modify.changes.entries
+                                .map((entry) => '${entry.key}:\n'
+                                    '  old: ${entry.value['old']}\n'
+                                    '  new: ${entry.value['new']}')
+                                .toList()
+                                .join('\n'),
                             style: TextStyle(
                               color: AppSettings.isDarkMode
                                   ? TaskWarriorColors.white
                                   : TaskWarriorColors.black,
                             ),
                           ),
-                          content: SingleChildScrollView(
-                            scrollDirection: Axis.horizontal,
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () {
+                              Get.back();
+                            },
                             child: Text(
-                              controller.modify.changes.entries
-                                  .map((entry) => '${entry.key}:\n'
-                                      '  old: ${entry.value['old']}\n'
-                                      '  new: ${entry.value['new']}')
-                                  .toList()
-                                  .join('\n'),
+                              'Cancel',
                               style: TextStyle(
                                 color: AppSettings.isDarkMode
                                     ? TaskWarriorColors.white
@@ -188,36 +212,21 @@ class DetailRouteView extends GetView<DetailRouteController> {
                               ),
                             ),
                           ),
-                          actions: [
-                            TextButton(
-                              onPressed: () {
-                                Get.back();
-                              },
-                              child: Text(
-                                'Cancel',
-                                style: TextStyle(
-                                  color: AppSettings.isDarkMode
-                                      ? TaskWarriorColors.white
-                                      : TaskWarriorColors.black,
-                                ),
+                          ElevatedButton(
+                            onPressed: () {
+                              controller.saveChanges();
+                            },
+                            child: Text(
+                              'Submit',
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.black
+                                    : TaskWarriorColors.black,
                               ),
                             ),
-                            ElevatedButton(
-                              onPressed: () {
-                                controller.saveChanges();
-                              },
-                              child: Text(
-                                'Submit',
-                                style: TextStyle(
-                                  color: AppSettings.isDarkMode
-                                      ? TaskWarriorColors.black
-                                      : TaskWarriorColors.black,
-                                ),
-                              ),
-                            ),
-                          ],
-                        );
-                      },
+                          ),
+                        ],
+                      ),
                     );
                   },
                   child: const Icon(Icons.save),
@@ -385,15 +394,7 @@ class TagsWidget extends StatelessWidget {
                           color: AppSettings.isDarkMode
                               ? TaskWarriorColors.white
                               : TaskWarriorColors.black,
-                        )
-                        // style: GoogleFonts.poppins(
-                        //   fontWeight: TaskWarriorFonts.bold,
-                        //   fontSize: TaskWarriorFonts.fontSizeMedium,
-                        //   color: AppSettings.isDarkMode
-                        //       ? TaskWarriorColors.white
-                        //       : TaskWarriorColors.black,
-                        // ),
-                        ),
+                        )),
                     TextSpan(
                       text:
                           '${(value as ListBuilder?)?.build() ?? 'not selected'}',

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -57,6 +57,8 @@ class HomeController extends GetxController {
   late TaskDatabase taskdb;
   var tasks = <Tasks>[].obs;
   final RxBool isRefreshing = false.obs;
+  final RxBool isFilterTourActive = false.obs;
+  final RxBool isHomeTourActive = false.obs;
 
   @override
   void onInit() {
@@ -608,6 +610,7 @@ class HomeController extends GetxController {
         opacityShadow: 0.8,
         hideSkip: true,
         onFinish: () {
+          isHomeTourActive.value = false;
           SaveTourStatus.saveInAppTourStatus(true);
         });
   }
@@ -619,6 +622,7 @@ class HomeController extends GetxController {
         SaveTourStatus.getInAppTourStatus().then((value) => {
               if (value == false)
                 {
+                  isHomeTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else
@@ -652,6 +656,7 @@ class HomeController extends GetxController {
       opacityShadow: 1.00,
       hideSkip: true,
       onFinish: () {
+        isFilterTourActive.value = false;
         SaveTourStatus.saveFilterTourStatus(true);
       },
     );
@@ -664,6 +669,7 @@ class HomeController extends GetxController {
         SaveTourStatus.getFilterTourStatus().then((value) => {
               if (value == false)
                 {
+                  isFilterTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else

--- a/lib/app/modules/home/views/filter_drawer_home_page.dart
+++ b/lib/app/modules/home/views/filter_drawer_home_page.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: unrelated_type_equality_checks
 
 import 'package:flutter/material.dart';
-import 'package:get/get_state_manager/get_state_manager.dart';
+import 'package:get/get.dart';
 import 'package:taskwarrior/app/models/filters.dart';
 import 'package:taskwarrior/app/modules/home/controllers/home_controller.dart';
 import 'package:taskwarrior/app/modules/home/views/project_column_home_page.dart';
@@ -26,441 +26,463 @@ class FilterDrawer extends StatelessWidget {
     var tileColor = AppSettings.isDarkMode
         ? TaskWarriorColors.ksecondaryBackgroundColor
         : TaskWarriorColors.kLightPrimaryBackgroundColor;
-    return Drawer(
-      backgroundColor: AppSettings.isDarkMode
-          ? TaskWarriorColors.kprimaryBackgroundColor
-          : TaskWarriorColors.kLightPrimaryBackgroundColor,
-      surfaceTintColor: AppSettings.isDarkMode
-          ? TaskWarriorColors.kprimaryBackgroundColor
-          : TaskWarriorColors.kLightPrimaryBackgroundColor,
-      child: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: ListView(
-            primary: false,
-            key: const PageStorageKey('tags-filter'),
-            children: [
-              const Divider(
-                color: Color.fromARGB(0, 48, 46, 46),
-              ),
-              Container(
-                height: 45,
-                alignment: Alignment.center,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                  child: Text(
-                    SentenceManager(
-                            currentLanguage:
-                                homeController.selectedLanguage.value)
-                        .sentences
-                        .filterDrawerApplyFilters,
-                    // style: GoogleFonts.poppins(
-                    //     fontWeight: TaskWarriorFonts.bold,
-                    //     color: (AppSettings.isDarkMode
-                    //         ? TaskWarriorColors.kprimaryTextColor
-                    //         : TaskWarriorColors.kLightPrimaryTextColor),
-                    //     fontSize: TaskWarriorFonts.fontSizeExtraLarge),
-                    style: TextStyle(
-                      fontFamily: FontFamily.poppins,
-                      fontWeight: TaskWarriorFonts.bold,
-                      color: (AppSettings.isDarkMode
-                          ? TaskWarriorColors.kprimaryTextColor
-                          : TaskWarriorColors.kLightPrimaryTextColor),
-                      fontSize: TaskWarriorFonts.fontSizeExtraLarge,
-                    ),
+    return Obx(() => PopScope(
+        canPop: !homeController.isFilterTourActive.value,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (homeController.isFilterTourActive.value) {
+           Get.closeAllSnackbars();
+            Get.snackbar(
+              'Tour Active',
+              'Please complete the tour before navigating back.',
+              snackPosition: SnackPosition.BOTTOM,
+            );
+            return;
+          }
+        },
+        child: Drawer(
+          backgroundColor: AppSettings.isDarkMode
+              ? TaskWarriorColors.kprimaryBackgroundColor
+              : TaskWarriorColors.kLightPrimaryBackgroundColor,
+          surfaceTintColor: AppSettings.isDarkMode
+              ? TaskWarriorColors.kprimaryBackgroundColor
+              : TaskWarriorColors.kLightPrimaryBackgroundColor,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: ListView(
+                primary: false,
+                key: const PageStorageKey('tags-filter'),
+                children: [
+                  const Divider(
+                    color: Color.fromARGB(0, 48, 46, 46),
                   ),
-                ),
-              ),
-              const Divider(
-                color: Color.fromARGB(0, 48, 46, 46),
-              ),
-              Container(
-                // width: MediaQuery.of(context).size.width * 1,
-                // padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: tileColor,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: TaskWarriorColors.borderColor),
-                ),
-                child: ListTile(
-                  contentPadding: const EdgeInsets.only(
-                    left: 8,
-                  ),
-                  title: RichText(
-                    key: homeController.statusKey,
-                    maxLines: 2,
-                    text: TextSpan(
-                      children: <TextSpan>[
-                        TextSpan(
-                            text:
-                                '${SentenceManager(currentLanguage: homeController.selectedLanguage.value).sentences.filterDrawerStatus} : ',
-                            style: TextStyle(
-                              fontFamily: FontFamily.poppins,
-                              fontSize: TaskWarriorFonts.fontSizeMedium,
-                              color: AppSettings.isDarkMode
-                                  ? TaskWarriorColors.white
-                                  : TaskWarriorColors.black,
-                            )),
-                        TextSpan(
-                            text: filters.pendingFilter
-                                ? SentenceManager(
-                                        currentLanguage: homeController
-                                            .selectedLanguage.value)
-                                    .sentences
-                                    .filterDrawerPending
-                                : SentenceManager(
-                                        currentLanguage: homeController
-                                            .selectedLanguage.value)
-                                    .sentences
-                                    .filterDrawerCompleted,
-                            style: TextStyle(
-                              fontFamily: FontFamily.poppins,
-                              fontSize: TaskWarriorFonts.fontSizeMedium,
-                              color: AppSettings.isDarkMode
-                                  ? TaskWarriorColors.white
-                                  : TaskWarriorColors.black,
-                            )),
-                      ],
-                    ),
-                  ),
-                  onTap: filters.togglePendingFilter,
-                  textColor: AppSettings.isDarkMode
-                      ? TaskWarriorColors.kprimaryTextColor
-                      : TaskWarriorColors.kLightSecondaryTextColor,
-                ),
-              ),
-              const Divider(
-                color: Color.fromARGB(0, 48, 46, 46),
-              ),
-              Container(
-                decoration: BoxDecoration(
-                  color: tileColor,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: TaskWarriorColors.borderColor),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                          !filters.waitingFilter
-                              ? SentenceManager(
-                                      currentLanguage:
-                                          homeController.selectedLanguage.value)
-                                  .sentences
-                                  .filterDrawerShowWaiting
-                              : SentenceManager(
-                                      currentLanguage:
-                                          homeController.selectedLanguage.value)
-                                  .sentences
-                                  .filterDrawerHideWaiting,
-                          style: TextStyle(
-                            fontFamily: FontFamily.poppins,
-                            fontSize: TaskWarriorFonts.fontSizeMedium,
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.kprimaryTextColor
-                                : TaskWarriorColors.kLightSecondaryTextColor,
-                          )),
-                      Switch(
-                        value: filters.waitingFilter,
-                        onChanged: (_) => filters.toggleWaitingFilter(),
-                      )
-                    ],
-                  ),
-                ),
-              ),
-              const Divider(
-                color: Color.fromARGB(0, 48, 46, 46),
-              ),
-              Visibility(
-                visible: !homeController.taskchampion.value,
-                child: Container(
-                  key: homeController.projectsKey,
-                  width: MediaQuery.of(context).size.width * 1,
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: tileColor,
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: TaskWarriorColors.borderColor,
-                    ),
-                  ),
-                  child: ProjectsColumn(
-                    projects: filters.projects,
-                    projectFilter: filters.projectFilter,
-                    callback: filters.toggleProjectFilter,
-                  ),
-                ),
-              ),
-              Visibility(
-                visible: homeController.taskchampion.value,
-                child: FutureBuilder<List<String>>(
-                  future: homeController.getUniqueProjects(),
-                  builder: (BuildContext context,
-                      AsyncSnapshot<List<String>> snapshot) {
-                    if (snapshot.hasData) {
-                      return Container(
-                        key: homeController.projectsKeyTaskc,
-                        width: MediaQuery.of(context).size.width * 1,
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: tileColor,
-                          borderRadius: BorderRadius.circular(8),
-                          border:
-                              Border.all(color: TaskWarriorColors.borderColor),
-                        ),
-                        child: ProjectColumnTaskc(
-                          callback: filters.toggleProjectFilter,
-                          projects: snapshot.data!,
-                          projectFilter: filters.projectFilter,
-                        ),
-                      );
-                    } else {
-                      return const Center(
-                          child: Text('No projects available.'));
-                    }
-                  },
-                ),
-              ),
-              const Divider(
-                color: Color.fromARGB(0, 48, 46, 46),
-              ),
-              Visibility(
-                visible: !homeController.taskchampion.value,
-                child: Container(
-                  key: homeController.filterTagKey,
-                  width: MediaQuery.of(context).size.width * 1,
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: tileColor,
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: TaskWarriorColors.borderColor),
-                  ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      const Divider(
-                        color: Color.fromARGB(0, 48, 46, 46),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                        child: Text(
-                          SentenceManager(
-                                  currentLanguage:
-                                      homeController.selectedLanguage.value)
-                              .sentences
-                              .filterDrawerFilterTagBy,
-                          // style: GoogleFonts.poppins(
-                          //     color: (AppSettings.isDarkMode
-                          //         ? TaskWarriorColors.kprimaryTextColor
-                          //         : TaskWarriorColors.kLightSecondaryTextColor),
-                          //     //
-                          //     fontSize: TaskWarriorFonts.fontSizeLarge),
-                          //textAlign: TextAlign.right,
-                          style: TextStyle(
-                            fontFamily: FontFamily.poppins,
-                            fontSize: TaskWarriorFonts.fontSizeMedium,
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.kprimaryTextColor
-                                : TaskWarriorColors.kLightSecondaryTextColor,
-                          ),
-                        ),
-                      ),
-                      const Divider(
-                        color: Color.fromARGB(0, 48, 46, 46),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                        child: TagFiltersWrap(filters.tagFilters),
-                      ),
-                      const Divider(
-                        color: Color.fromARGB(0, 48, 46, 46),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Visibility(
-                visible: !homeController.taskchampion.value,
-                child: const Divider(
-                  color: Color.fromARGB(0, 48, 46, 46),
-                ),
-              ),
-              Container(
-                key: homeController.sortByKey,
-                width: MediaQuery.of(context).size.width * 1,
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: tileColor,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: TaskWarriorColors.borderColor),
-                ),
-                //height: 30,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const Divider(
-                      color: Color.fromARGB(0, 48, 46, 46),
-                    ),
-                    Padding(
+                  Container(
+                    height: 45,
+                    alignment: Alignment.center,
+                    child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 0.0),
                       child: Text(
-                          SentenceManager(
-                                  currentLanguage:
-                                      homeController.selectedLanguage.value)
-                              .sentences
-                              .filterDrawerSortBy,
-                          // style: GoogleFonts.poppins(
-                          //     color: (AppSettings.isDarkMode
-                          //         ? TaskWarriorColors.kprimaryTextColor
-                          //         : TaskWarriorColors.kLightPrimaryTextColor),
-                          //     fontSize: TaskWarriorFonts.fontSizeLarge),
-                          // textAlign: TextAlign.right,
-                          style: TextStyle(
-                            fontFamily: FontFamily.poppins,
-                            fontSize: TaskWarriorFonts.fontSizeMedium,
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          )),
+                        SentenceManager(
+                                currentLanguage:
+                                    homeController.selectedLanguage.value)
+                            .sentences
+                            .filterDrawerApplyFilters,
+                        // style: GoogleFonts.poppins(
+                        //     fontWeight: TaskWarriorFonts.bold,
+                        //     color: (AppSettings.isDarkMode
+                        //         ? TaskWarriorColors.kprimaryTextColor
+                        //         : TaskWarriorColors.kLightPrimaryTextColor),
+                        //     fontSize: TaskWarriorFonts.fontSizeExtraLarge),
+                        style: TextStyle(
+                          fontFamily: FontFamily.poppins,
+                          fontWeight: TaskWarriorFonts.bold,
+                          color: (AppSettings.isDarkMode
+                              ? TaskWarriorColors.kprimaryTextColor
+                              : TaskWarriorColors.kLightPrimaryTextColor),
+                          fontSize: TaskWarriorFonts.fontSizeExtraLarge,
+                        ),
+                      ),
                     ),
-                    const Divider(
-                      color: Color.fromARGB(0, 48, 46, 46),
+                  ),
+                  const Divider(
+                    color: Color.fromARGB(0, 48, 46, 46),
+                  ),
+                  Container(
+                    // width: MediaQuery.of(context).size.width * 1,
+                    // padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: tileColor,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: TaskWarriorColors.borderColor),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: Wrap(
-                        spacing: 8,
-                        runSpacing: 4,
+                    child: ListTile(
+                      contentPadding: const EdgeInsets.only(
+                        left: 8,
+                      ),
+                      title: RichText(
+                        key: homeController.statusKey,
+                        maxLines: 2,
+                        text: TextSpan(
+                          children: <TextSpan>[
+                            TextSpan(
+                                text:
+                                    '${SentenceManager(currentLanguage: homeController.selectedLanguage.value).sentences.filterDrawerStatus} : ',
+                                style: TextStyle(
+                                  fontFamily: FontFamily.poppins,
+                                  fontSize: TaskWarriorFonts.fontSizeMedium,
+                                  color: AppSettings.isDarkMode
+                                      ? TaskWarriorColors.white
+                                      : TaskWarriorColors.black,
+                                )),
+                            TextSpan(
+                                text: filters.pendingFilter
+                                    ? SentenceManager(
+                                            currentLanguage: homeController
+                                                .selectedLanguage.value)
+                                        .sentences
+                                        .filterDrawerPending
+                                    : SentenceManager(
+                                            currentLanguage: homeController
+                                                .selectedLanguage.value)
+                                        .sentences
+                                        .filterDrawerCompleted,
+                                style: TextStyle(
+                                  fontFamily: FontFamily.poppins,
+                                  fontSize: TaskWarriorFonts.fontSizeMedium,
+                                  color: AppSettings.isDarkMode
+                                      ? TaskWarriorColors.white
+                                      : TaskWarriorColors.black,
+                                )),
+                          ],
+                        ),
+                      ),
+                      onTap: filters.togglePendingFilter,
+                      textColor: AppSettings.isDarkMode
+                          ? TaskWarriorColors.kprimaryTextColor
+                          : TaskWarriorColors.kLightSecondaryTextColor,
+                    ),
+                  ),
+                  const Divider(
+                    color: Color.fromARGB(0, 48, 46, 46),
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: tileColor,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: TaskWarriorColors.borderColor),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          for (var sort in [
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerCreated,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerModified,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerStartTime,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerDueTill,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerPriority,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerProject,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerTags,
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerUrgency,
-                          ])
-                            Obx(
-                              () => ChoiceChip(
-                                label: (homeController.selectedSort.value
-                                        .startsWith(sort))
-                                    ? Text(
-                                        homeController.selectedSort.value,
-                                      )
-                                    : Text(sort),
-                                selected: false,
-                                onSelected: (_) {
-                                  if (homeController.selectedSort == '$sort+') {
-                                    homeController.selectSort('$sort-');
-                                  } else if (homeController.selectedSort ==
-                                      '$sort-') {
-                                    homeController.selectSort(sort);
-                                  } else {
-                                    homeController.selectSort('$sort+');
-                                  }
-                                },
-                                // labelStyle: GoogleFonts.poppins(
-                                //     color: AppSettings.isDarkMode
-                                //         ? TaskWarriorColors.black
-                                //         : TaskWarriorColors.white),
-                                // backgroundColor: AppSettings.isDarkMode
-                                //     ? TaskWarriorColors
-                                //         .kLightSecondaryBackgroundColor
-                                //     : TaskWarriorColors.ksecondaryBackgroundColor,
-                              ),
-                            )
+                          Text(
+                              !filters.waitingFilter
+                                  ? SentenceManager(
+                                          currentLanguage: homeController
+                                              .selectedLanguage.value)
+                                      .sentences
+                                      .filterDrawerShowWaiting
+                                  : SentenceManager(
+                                          currentLanguage: homeController
+                                              .selectedLanguage.value)
+                                      .sentences
+                                      .filterDrawerHideWaiting,
+                              style: TextStyle(
+                                fontFamily: FontFamily.poppins,
+                                fontSize: TaskWarriorFonts.fontSizeMedium,
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.kprimaryTextColor
+                                    : TaskWarriorColors
+                                        .kLightSecondaryTextColor,
+                              )),
+                          Switch(
+                            value: filters.waitingFilter,
+                            onChanged: (_) => filters.toggleWaitingFilter(),
+                          )
                         ],
                       ),
                     ),
-                    const Divider(
-                      color: Color.fromARGB(0, 48, 46, 46),
-                    ),
-                    Container(
-                      width: 200,
+                  ),
+                  const Divider(
+                    color: Color.fromARGB(0, 48, 46, 46),
+                  ),
+                  Visibility(
+                    visible: !homeController.taskchampion.value,
+                    child: Container(
+                      key: homeController.projectsKey,
+                      width: MediaQuery.of(context).size.width * 1,
+                      padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        // color: AppSettings.isDarkMode
-                        //     ? TaskWarriorColors.kLightSecondaryBackgroundColor
-                        //     : TaskWarriorColors.ksecondaryBackgroundColor,
+                        color: tileColor,
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(
+                          color: TaskWarriorColors.borderColor,
+                        ),
                       ),
-                      child: TextButton(
-                        onPressed: () {
-                          if (homeController.selectedSort.value.endsWith('+') ||
-                              homeController.selectedSort.value.endsWith('-')) {
-                            homeController.selectSort(
-                                homeController.selectedSort.value.substring(
-                                    0,
-                                    homeController.selectedSort.value.length -
-                                        1));
-                          }
-                        },
-                        child: Text(
-                            SentenceManager(
-                                    currentLanguage:
-                                        homeController.selectedLanguage.value)
-                                .sentences
-                                .filterDrawerResetSort,
-                            // style: GoogleFonts.poppins(
-                            //     fontSize: TaskWarriorFonts.fontSizeMedium,
-                            //     color: AppSettings.isDarkMode
-                            //         ? TaskWarriorColors.kLightSecondaryTextColor
-                            //         : TaskWarriorColors.ksecondaryTextColor),
-                            style: TextStyle(
-                              fontFamily: FontFamily.poppins,
-                              fontSize: TaskWarriorFonts.fontSizeMedium,
-                              color: AppSettings.isDarkMode
-                                  ? TaskWarriorColors.white
-                                  : TaskWarriorColors.black,
-                            )),
+                      child: ProjectsColumn(
+                        projects: filters.projects,
+                        projectFilter: filters.projectFilter,
+                        callback: filters.toggleProjectFilter,
                       ),
                     ),
-                    const Divider(
+                  ),
+                  Visibility(
+                    visible: homeController.taskchampion.value,
+                    child: FutureBuilder<List<String>>(
+                      future: homeController.getUniqueProjects(),
+                      builder: (BuildContext context,
+                          AsyncSnapshot<List<String>> snapshot) {
+                        if (snapshot.hasData) {
+                          return Container(
+                            key: homeController.projectsKeyTaskc,
+                            width: MediaQuery.of(context).size.width * 1,
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: tileColor,
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(
+                                  color: TaskWarriorColors.borderColor),
+                            ),
+                            child: ProjectColumnTaskc(
+                              callback: filters.toggleProjectFilter,
+                              projects: snapshot.data!,
+                              projectFilter: filters.projectFilter,
+                            ),
+                          );
+                        } else {
+                          return const Center(
+                              child: Text('No projects available.'));
+                        }
+                      },
+                    ),
+                  ),
+                  const Divider(
+                    color: Color.fromARGB(0, 48, 46, 46),
+                  ),
+                  Visibility(
+                    visible: !homeController.taskchampion.value,
+                    child: Container(
+                      key: homeController.filterTagKey,
+                      width: MediaQuery.of(context).size.width * 1,
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: tileColor,
+                        borderRadius: BorderRadius.circular(8),
+                        border:
+                            Border.all(color: TaskWarriorColors.borderColor),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const Divider(
+                            color: Color.fromARGB(0, 48, 46, 46),
+                          ),
+                          Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 0.0),
+                            child: Text(
+                              SentenceManager(
+                                      currentLanguage:
+                                          homeController.selectedLanguage.value)
+                                  .sentences
+                                  .filterDrawerFilterTagBy,
+                              // style: GoogleFonts.poppins(
+                              //     color: (AppSettings.isDarkMode
+                              //         ? TaskWarriorColors.kprimaryTextColor
+                              //         : TaskWarriorColors.kLightSecondaryTextColor),
+                              //     //
+                              //     fontSize: TaskWarriorFonts.fontSizeLarge),
+                              //textAlign: TextAlign.right,
+                              style: TextStyle(
+                                fontFamily: FontFamily.poppins,
+                                fontSize: TaskWarriorFonts.fontSizeMedium,
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.kprimaryTextColor
+                                    : TaskWarriorColors
+                                        .kLightSecondaryTextColor,
+                              ),
+                            ),
+                          ),
+                          const Divider(
+                            color: Color.fromARGB(0, 48, 46, 46),
+                          ),
+                          Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 8.0),
+                            child: TagFiltersWrap(filters.tagFilters),
+                          ),
+                          const Divider(
+                            color: Color.fromARGB(0, 48, 46, 46),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible: !homeController.taskchampion.value,
+                    child: const Divider(
                       color: Color.fromARGB(0, 48, 46, 46),
                     ),
-                  ],
-                ),
-              )
-            ],
+                  ),
+                  Container(
+                    key: homeController.sortByKey,
+                    width: MediaQuery.of(context).size.width * 1,
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: tileColor,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: TaskWarriorColors.borderColor),
+                    ),
+                    //height: 30,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const Divider(
+                          color: Color.fromARGB(0, 48, 46, 46),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                          child: Text(
+                              SentenceManager(
+                                      currentLanguage:
+                                          homeController.selectedLanguage.value)
+                                  .sentences
+                                  .filterDrawerSortBy,
+                              // style: GoogleFonts.poppins(
+                              //     color: (AppSettings.isDarkMode
+                              //         ? TaskWarriorColors.kprimaryTextColor
+                              //         : TaskWarriorColors.kLightPrimaryTextColor),
+                              //     fontSize: TaskWarriorFonts.fontSizeLarge),
+                              // textAlign: TextAlign.right,
+                              style: TextStyle(
+                                fontFamily: FontFamily.poppins,
+                                fontSize: TaskWarriorFonts.fontSizeMedium,
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              )),
+                        ),
+                        const Divider(
+                          color: Color.fromARGB(0, 48, 46, 46),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                          child: Wrap(
+                            spacing: 8,
+                            runSpacing: 4,
+                            children: [
+                              for (var sort in [
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerCreated,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerModified,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerStartTime,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerDueTill,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerPriority,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerProject,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerTags,
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerUrgency,
+                              ])
+                                Obx(
+                                  () => ChoiceChip(
+                                    label: (homeController.selectedSort.value
+                                            .startsWith(sort))
+                                        ? Text(
+                                            homeController.selectedSort.value,
+                                          )
+                                        : Text(sort),
+                                    selected: false,
+                                    onSelected: (_) {
+                                      if (homeController.selectedSort ==
+                                          '$sort+') {
+                                        homeController.selectSort('$sort-');
+                                      } else if (homeController.selectedSort ==
+                                          '$sort-') {
+                                        homeController.selectSort(sort);
+                                      } else {
+                                        homeController.selectSort('$sort+');
+                                      }
+                                    },
+                                    // labelStyle: GoogleFonts.poppins(
+                                    //     color: AppSettings.isDarkMode
+                                    //         ? TaskWarriorColors.black
+                                    //         : TaskWarriorColors.white),
+                                    // backgroundColor: AppSettings.isDarkMode
+                                    //     ? TaskWarriorColors
+                                    //         .kLightSecondaryBackgroundColor
+                                    //     : TaskWarriorColors.ksecondaryBackgroundColor,
+                                  ),
+                                )
+                            ],
+                          ),
+                        ),
+                        const Divider(
+                          color: Color.fromARGB(0, 48, 46, 46),
+                        ),
+                        Container(
+                          width: 200,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(10),
+                            // color: AppSettings.isDarkMode
+                            //     ? TaskWarriorColors.kLightSecondaryBackgroundColor
+                            //     : TaskWarriorColors.ksecondaryBackgroundColor,
+                          ),
+                          child: TextButton(
+                            onPressed: () {
+                              if (homeController.selectedSort.value
+                                      .endsWith('+') ||
+                                  homeController.selectedSort.value
+                                      .endsWith('-')) {
+                                homeController.selectSort(
+                                    homeController.selectedSort.value.substring(
+                                        0,
+                                        homeController
+                                                .selectedSort.value.length -
+                                            1));
+                              }
+                            },
+                            child: Text(
+                                SentenceManager(
+                                        currentLanguage: homeController
+                                            .selectedLanguage.value)
+                                    .sentences
+                                    .filterDrawerResetSort,
+                                // style: GoogleFonts.poppins(
+                                //     fontSize: TaskWarriorFonts.fontSizeMedium,
+                                //     color: AppSettings.isDarkMode
+                                //         ? TaskWarriorColors.kLightSecondaryTextColor
+                                //         : TaskWarriorColors.ksecondaryTextColor),
+                                style: TextStyle(
+                                  fontFamily: FontFamily.poppins,
+                                  fontSize: TaskWarriorFonts.fontSizeMedium,
+                                  color: AppSettings.isDarkMode
+                                      ? TaskWarriorColors.white
+                                      : TaskWarriorColors.black,
+                                )),
+                          ),
+                        ),
+                        const Divider(
+                          color: Color.fromARGB(0, 48, 46, 46),
+                        ),
+                      ],
+                    ),
+                  )
+                ],
+              ),
+            ),
           ),
-        ),
-      ),
-    );
+        )));
   }
 }

--- a/lib/app/modules/home/views/home_page_body.dart
+++ b/lib/app/modules/home/views/home_page_body.dart
@@ -1,5 +1,6 @@
-import 'package:double_back_to_close_app/double_back_to_close_app.dart';
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:get/get.dart';
 import 'package:taskwarrior/app/modules/home/views/show_tasks.dart';
@@ -11,118 +12,162 @@ import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 
 import '../controllers/home_controller.dart';
 
-class HomePageBody extends StatelessWidget {
+class HomePageBody extends StatefulWidget {
   final HomeController controller;
   const HomePageBody({required this.controller, super.key});
 
   @override
+  State<HomePageBody> createState() => _HomePageBodyState();
+}
+
+class _HomePageBodyState extends State<HomePageBody> {
+  DateTime? _lastBackPressTime;
+  Timer? _backPressTimer;
+
+  @override
+  void dispose() {
+    _backPressTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    controller.initInAppTour();
-    controller.showInAppTour(context);
-    return DoubleBackToCloseApp(
-      snackBar: const SnackBar(content: Text('Tap back again to exit')),
-      child: Container(
-        color: AppSettings.isDarkMode
-            ? Palette.kToDark.shade200
-            : TaskWarriorColors.white,
-        child: Padding(
-          padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-          child: Obx(
-            () => Column(
-              children: <Widget>[
-                if (controller.searchVisible.value)
-                  Container(
-                    margin: const EdgeInsets.symmetric(
-                        horizontal: 10, vertical: 10),
-                    child: SearchBar(
-                      backgroundColor: WidgetStateProperty.all<Color>(
-                          (TaskWarriorColors.kLightPrimaryBackgroundColor)),
-                      surfaceTintColor: WidgetStateProperty.all<Color>(
-                          (TaskWarriorColors.kLightPrimaryBackgroundColor)),
-                      controller: controller.searchController,
-                      // shape:,
-                      onChanged: (value) {
-                        controller.search(value);
-                      },
+    widget.controller.initInAppTour();
+    widget.controller.showInAppTour(context);
+    return PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (widget.controller.isHomeTourActive.value) {
+            return;
+          }
 
-                      shape: WidgetStateProperty.resolveWith<OutlinedBorder?>(
-                        (Set<WidgetState> states) {
-                          if (states.contains(WidgetState.focused)) {
-                            return RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12.0),
-                              side: BorderSide(
-                                color: TaskWarriorColors.black,
-                                width: 2.0,
-                              ),
-                            );
-                          } else {
-                            return RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12.0),
-                              side: BorderSide(
-                                color: TaskWarriorColors.black,
-                                width: 1.5,
-                              ),
-                            );
-                          }
+          final now = DateTime.now();
+          if (_lastBackPressTime != null &&
+              now.difference(_lastBackPressTime!) <=
+                  const Duration(seconds: 2)) {
+            _backPressTimer?.cancel();
+            SystemChannels.platform.invokeMethod('SystemNavigator.pop');
+            return;
+          } else {
+            _lastBackPressTime = now;
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Tap back again to exit')),
+            );
+
+            _backPressTimer?.cancel();
+            _backPressTimer = Timer(const Duration(seconds: 2), () {
+              _lastBackPressTime = null;
+            });
+
+            return;
+          }
+        },
+        child: Container(
+          color: AppSettings.isDarkMode
+              ? Palette.kToDark.shade200
+              : TaskWarriorColors.white,
+          child: Padding(
+            padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+            child: Obx(
+              () => Column(
+                children: <Widget>[
+                  if (widget.controller.searchVisible.value)
+                    Container(
+                      margin: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 10),
+                      child: SearchBar(
+                        backgroundColor: WidgetStateProperty.all<Color>(
+                            (TaskWarriorColors.kLightPrimaryBackgroundColor)),
+                        surfaceTintColor: WidgetStateProperty.all<Color>(
+                            (TaskWarriorColors.kLightPrimaryBackgroundColor)),
+                        controller: widget.controller.searchController,
+                        // shape:,
+                        onChanged: (value) {
+                          widget.controller.search(value);
                         },
-                      ),
-                      leading: const Icon(Icons.search_rounded),
-                      trailing: <Widget>[
-                        (controller.searchController.text.isNotEmpty)
-                            ? IconButton(
-                                key: GlobalKey(),
-                                icon: Icon(Icons.cancel,
-                                    color: TaskWarriorColors.black),
-                                onPressed: () {
-                                  controller.searchController.clear();
-                                  controller
-                                      .search(controller.searchController.text);
-                                },
-                              )
-                            : const SizedBox(
-                                width: 0,
-                                height: 0,
-                              )
-                      ],
 
-                      hintText: 'Search',
+                        shape: WidgetStateProperty.resolveWith<OutlinedBorder?>(
+                          (Set<WidgetState> states) {
+                            if (states.contains(WidgetState.focused)) {
+                              return RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12.0),
+                                side: BorderSide(
+                                  color: TaskWarriorColors.black,
+                                  width: 2.0,
+                                ),
+                              );
+                            } else {
+                              return RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12.0),
+                                side: BorderSide(
+                                  color: TaskWarriorColors.black,
+                                  width: 1.5,
+                                ),
+                              );
+                            }
+                          },
+                        ),
+                        leading: const Icon(Icons.search_rounded),
+                        trailing: <Widget>[
+                          (widget.controller.searchController.text.isNotEmpty)
+                              ? IconButton(
+                                  key: GlobalKey(),
+                                  icon: Icon(Icons.cancel,
+                                      color: TaskWarriorColors.black),
+                                  onPressed: () {
+                                    widget.controller.searchController.clear();
+                                    widget.controller.search(widget
+                                        .controller.searchController.text);
+                                  },
+                                )
+                              : const SizedBox(
+                                  width: 0,
+                                  height: 0,
+                                )
+                        ],
+
+                        hintText: 'Search',
+                      ),
                     ),
-                  ),
-                Visibility(
-                  visible: !controller.taskchampion.value,
-                  child: Expanded(
-                    child: Scrollbar(
-                      child: Obx(
-                        () => TasksBuilder(
-                          // darkmode: AppSettings.isDarkMode,
-                          useDelayTask: controller.useDelayTask.value,
-                          taskData: controller.searchedTasks,
-                          pendingFilter: controller.pendingFilter.value,
-                          waitingFilter: controller.waitingFilter.value,
-                          searchVisible: controller.searchVisible.value,
-                          selectedLanguage: controller.selectedLanguage.value,
-                          scrollController: controller.scrollController,
-                          showbtn: controller.showbtn.value,
+                  Visibility(
+                    visible: !widget.controller.taskchampion.value,
+                    child: Expanded(
+                      child: Scrollbar(
+                        child: Obx(
+                          () => TasksBuilder(
+                            // darkmode: AppSettings.isDarkMode,
+                            useDelayTask: widget.controller.useDelayTask.value,
+                            taskData: widget.controller.searchedTasks,
+                            pendingFilter:
+                                widget.controller.pendingFilter.value,
+                            waitingFilter:
+                                widget.controller.waitingFilter.value,
+                            searchVisible:
+                                widget.controller.searchVisible.value,
+                            selectedLanguage:
+                                widget.controller.selectedLanguage.value,
+                            scrollController:
+                                widget.controller.scrollController,
+                            showbtn: widget.controller.showbtn.value,
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
-                Visibility(
-                    visible: controller.taskchampion.value,
-                    child: Expanded(
-                        child: Scrollbar(
-                      child: TaskViewBuilder(
-                        pendingFilter: controller.pendingFilter.value,
-                        selectedSort: controller.selectedSort.value,
-                        project: controller.projectFilter.value,
-                      ),
-                    )))
-              ],
+                  Visibility(
+                      visible: widget.controller.taskchampion.value,
+                      child: Expanded(
+                          child: Scrollbar(
+                        child: TaskViewBuilder(
+                          pendingFilter: widget.controller.pendingFilter.value,
+                          selectedSort: widget.controller.selectedSort.value,
+                          project: widget.controller.projectFilter.value,
+                        ),
+                      )))
+                ],
+              ),
             ),
           ),
-        ),
-      ),
-    );
+        ));
   }
 }

--- a/lib/app/modules/manageTaskServer/controllers/manage_task_server_controller.dart
+++ b/lib/app/modules/manageTaskServer/controllers/manage_task_server_controller.dart
@@ -26,6 +26,7 @@ class ManageTaskServerController extends GetxController {
   final TextEditingController taskrcContentController = TextEditingController();
   RxBool isTaskDServerActive = true.obs;
   RxBool hideKey = true.obs;
+  final RxBool isManageServerTourActive = false.obs;
 
   @override
   void onInit() {
@@ -220,6 +221,7 @@ class ManageTaskServerController extends GetxController {
       opacityShadow: 1.00,
       hideSkip: true,
       onFinish: () {
+        isManageServerTourActive.value = false;
         SaveTourStatus.saveManageTaskServerTourStatus(true);
       },
     );
@@ -232,6 +234,7 @@ class ManageTaskServerController extends GetxController {
         SaveTourStatus.getManageTaskServerTourStatus().then((value) => {
               if (value == false)
                 {
+                  isManageServerTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else

--- a/lib/app/modules/manageTaskServer/views/manage_task_server_page_body.dart
+++ b/lib/app/modules/manageTaskServer/views/manage_task_server_page_body.dart
@@ -20,521 +20,553 @@ class ManageTaskServerPageBody extends StatelessWidget {
   Widget build(BuildContext context) {
     controller.initManageTaskServerPageTour();
     controller.showManageTaskServerPageTour(context);
-    return Padding(
-      padding: const EdgeInsets.only(left: 20, right: 20),
-      child: ListView(
-        // mainAxisAlignment: MainAxisAlignment.start,
-        // crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            key: controller.configureTaskRC,
-            padding: const EdgeInsets.only(
-              top: 10,
-              bottom: 10,
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  SentenceManager(currentLanguage: AppSettings.selectedLanguage)
-                      .sentences
-                      .manageTaskServerPageConfigureTASKRC,
-                  style: TextStyle(
-                    color: AppSettings.isDarkMode
-                        ? TaskWarriorColors.white
-                        : TaskWarriorColors.black,
-                  ),
+    return Obx(() => PopScope(
+        canPop: !controller.isManageServerTourActive.value,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (controller.isManageServerTourActive.value) {
+            Get.closeAllSnackbars();
+            Get.snackbar(
+              'Tour Active',
+              'Please complete the tour before navigating back.',
+              snackPosition: SnackPosition.BOTTOM,
+            );
+            return;
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20),
+          child: ListView(
+            // mainAxisAlignment: MainAxisAlignment.start,
+            // crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                key: controller.configureTaskRC,
+                padding: const EdgeInsets.only(
+                  top: 10,
+                  bottom: 10,
                 ),
-                const SizedBox(height: 10),
-                GestureDetector(
-                  onTap: () {
-                    showModalBottomSheet(
-                      context: context,
-                      isScrollControlled: true,
-                      backgroundColor: AppSettings.isDarkMode
-                          ? TaskWarriorColors.kdialogBackGroundColor
-                          : TaskWarriorColors.kLightDialogBackGroundColor,
-                      builder: (context) {
-                        return StatefulBuilder(
-                          builder:
-                              (BuildContext context, StateSetter setState) {
-                            // double heightOfModalBottomSheet =
-                            //     MediaQuery.of(context).size.height * 0.6;
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      SentenceManager(
+                              currentLanguage: AppSettings.selectedLanguage)
+                          .sentences
+                          .manageTaskServerPageConfigureTASKRC,
+                      style: TextStyle(
+                        color: AppSettings.isDarkMode
+                            ? TaskWarriorColors.white
+                            : TaskWarriorColors.black,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    GestureDetector(
+                      onTap: () {
+                        showModalBottomSheet(
+                          context: context,
+                          isScrollControlled: true,
+                          backgroundColor: AppSettings.isDarkMode
+                              ? TaskWarriorColors.kdialogBackGroundColor
+                              : TaskWarriorColors.kLightDialogBackGroundColor,
+                          builder: (context) {
+                            return StatefulBuilder(
+                              builder:
+                                  (BuildContext context, StateSetter setState) {
+                                // double heightOfModalBottomSheet =
+                                //     MediaQuery.of(context).size.height * 0.6;
 
-                            return Padding(
-                              padding: MediaQuery.of(context).viewInsets,
-                              child: Wrap(
-                                children: [
-                                  Container(
-                                    // height: heightOfModalBottomSheet,
-                                    padding: const EdgeInsets.all(16.0),
-                                    decoration: const BoxDecoration(
-                                      // color: tileColor,
-                                      borderRadius: BorderRadius.vertical(
-                                          top: Radius.circular(16.0)),
-                                    ),
+                                return Padding(
+                                  padding: MediaQuery.of(context).viewInsets,
+                                  child: Wrap(
+                                    children: [
+                                      Container(
+                                        // height: heightOfModalBottomSheet,
+                                        padding: const EdgeInsets.all(16.0),
+                                        decoration: const BoxDecoration(
+                                          // color: tileColor,
+                                          borderRadius: BorderRadius.vertical(
+                                              top: Radius.circular(16.0)),
+                                        ),
 
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.center,
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          SentenceManager(
-                                                  currentLanguage: AppSettings
-                                                      .selectedLanguage)
-                                              .sentences
-                                              .manageTaskServerPageConfigureTaskRCDialogueBoxTitle,
-                                          style: TextStyle(
-                                            fontWeight: TaskWarriorFonts.bold,
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.white
-                                                : TaskWarriorColors.black,
-                                          ),
-                                        ),
-                                        Text(
-                                          SentenceManager(
-                                                  currentLanguage: AppSettings
-                                                      .selectedLanguage)
-                                              .sentences
-                                              .manageTaskServerPageConfigureTaskRCDialogueBoxSubtitle,
-                                          style: TextStyle(
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.white
-                                                : TaskWarriorColors.black,
-                                          ),
-                                        ),
-                                        const SizedBox(height: 16.0),
-                                        Padding(
-                                          padding: const EdgeInsets.all(12.0),
-                                          child: SizedBox(
-                                            height: Get.height * 0.15,
-                                            child: TextField(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.center,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              SentenceManager(
+                                                      currentLanguage:
+                                                          AppSettings
+                                                              .selectedLanguage)
+                                                  .sentences
+                                                  .manageTaskServerPageConfigureTaskRCDialogueBoxTitle,
                                               style: TextStyle(
-                                                  color: AppSettings.isDarkMode
-                                                      ? TaskWarriorColors.white
-                                                      : TaskWarriorColors
-                                                          .black),
-                                              controller: controller
-                                                  .taskrcContentController,
-                                              maxLines: 8,
-                                              decoration: InputDecoration(
-                                                counterStyle: TextStyle(
-                                                    color:
-                                                        AppSettings.isDarkMode
+                                                fontWeight:
+                                                    TaskWarriorFonts.bold,
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.white
+                                                    : TaskWarriorColors.black,
+                                              ),
+                                            ),
+                                            Text(
+                                              SentenceManager(
+                                                      currentLanguage:
+                                                          AppSettings
+                                                              .selectedLanguage)
+                                                  .sentences
+                                                  .manageTaskServerPageConfigureTaskRCDialogueBoxSubtitle,
+                                              style: TextStyle(
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.white
+                                                    : TaskWarriorColors.black,
+                                              ),
+                                            ),
+                                            const SizedBox(height: 16.0),
+                                            Padding(
+                                              padding:
+                                                  const EdgeInsets.all(12.0),
+                                              child: SizedBox(
+                                                height: Get.height * 0.15,
+                                                child: TextField(
+                                                  style: TextStyle(
+                                                      color:
+                                                          AppSettings.isDarkMode
+                                                              ? TaskWarriorColors
+                                                                  .white
+                                                              : TaskWarriorColors
+                                                                  .black),
+                                                  controller: controller
+                                                      .taskrcContentController,
+                                                  maxLines: 8,
+                                                  decoration: InputDecoration(
+                                                    counterStyle: TextStyle(
+                                                        color: AppSettings.isDarkMode
                                                             ? TaskWarriorColors
                                                                 .white
                                                             : TaskWarriorColors
                                                                 .black),
-                                                suffixIconConstraints:
-                                                    const BoxConstraints(
-                                                  maxHeight: 24,
-                                                  maxWidth: 24,
+                                                    suffixIconConstraints:
+                                                        const BoxConstraints(
+                                                      maxHeight: 24,
+                                                      maxWidth: 24,
+                                                    ),
+                                                    isDense: true,
+                                                    suffix: IconButton(
+                                                      onPressed: () async {
+                                                        controller.setContent(
+                                                            context);
+                                                      },
+                                                      icon: const Icon(
+                                                          Icons.content_paste),
+                                                    ),
+                                                    border:
+                                                        const OutlineInputBorder(),
+                                                    labelStyle: GoogleFonts
+                                                        .poppins(
+                                                            color: AppSettings
+                                                                    .isDarkMode
+                                                                ? TaskWarriorColors
+                                                                    .white
+                                                                : TaskWarriorColors
+                                                                    .black),
+                                                    labelText: SentenceManager(
+                                                            currentLanguage:
+                                                                AppSettings
+                                                                    .selectedLanguage)
+                                                        .sentences
+                                                        .manageTaskServerPageConfigureTaskRCDialogueBoxInputFieldText,
+                                                  ),
                                                 ),
-                                                isDense: true,
-                                                suffix: IconButton(
-                                                  onPressed: () async {
-                                                    controller
-                                                        .setContent(context);
-                                                  },
-                                                  icon: const Icon(
-                                                      Icons.content_paste),
-                                                ),
-                                                border:
-                                                    const OutlineInputBorder(),
-                                                labelStyle: GoogleFonts.poppins(
-                                                    color:
-                                                        AppSettings.isDarkMode
-                                                            ? TaskWarriorColors
-                                                                .white
-                                                            : TaskWarriorColors
-                                                                .black),
-                                                labelText: SentenceManager(
+                                              ),
+                                            ),
+                                            Text(
+                                              SentenceManager(
+                                                      currentLanguage:
+                                                          AppSettings
+                                                              .selectedLanguage)
+                                                  .sentences
+                                                  .manageTaskServerPageConfigureTaskRCDialogueBoxOr,
+                                              style: TextStyle(
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.white
+                                                    : TaskWarriorColors.black,
+                                              ),
+                                            ),
+                                            FilledButton.tonal(
+                                              style: ButtonStyle(
+                                                  backgroundColor: AppSettings
+                                                          .isDarkMode
+                                                      ? WidgetStateProperty.all<
+                                                              Color>(
+                                                          TaskWarriorColors
+                                                              .black)
+                                                      : WidgetStateProperty.all<
+                                                              Color>(
+                                                          TaskWarriorColors
+                                                              .white)),
+                                              onPressed: () async {
+                                                await setConfig(
+                                                  storage: controller.storage,
+                                                  key: 'TASKRC',
+                                                );
+                                                setState(() {});
+                                                Get.back();
+                                              },
+                                              child: Text(
+                                                SentenceManager(
                                                         currentLanguage:
                                                             AppSettings
                                                                 .selectedLanguage)
                                                     .sentences
-                                                    .manageTaskServerPageConfigureTaskRCDialogueBoxInputFieldText,
+                                                    .manageTaskServerPageConfigureTaskRCDialogueBoxSelectTaskRC,
+                                                style: TextStyle(
+                                                  color: AppSettings.isDarkMode
+                                                      ? TaskWarriorColors.white
+                                                      : TaskWarriorColors.black,
+                                                ),
                                               ),
                                             ),
-                                          ),
+                                          ],
                                         ),
-                                        Text(
-                                          SentenceManager(
-                                                  currentLanguage: AppSettings
-                                                      .selectedLanguage)
-                                              .sentences
-                                              .manageTaskServerPageConfigureTaskRCDialogueBoxOr,
-                                          style: TextStyle(
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.white
-                                                : TaskWarriorColors.black,
-                                          ),
-                                        ),
-                                        FilledButton.tonal(
-                                          style: ButtonStyle(
-                                              backgroundColor: AppSettings
-                                                      .isDarkMode
-                                                  ? WidgetStateProperty.all<
-                                                          Color>(
-                                                      TaskWarriorColors.black)
-                                                  : WidgetStateProperty.all<
-                                                          Color>(
-                                                      TaskWarriorColors.white)),
-                                          onPressed: () async {
-                                            await setConfig(
-                                              storage: controller.storage,
-                                              key: 'TASKRC',
-                                            );
-                                            setState(() {});
-                                            Get.back();
-                                          },
-                                          child: Text(
-                                            SentenceManager(
-                                                    currentLanguage: AppSettings
-                                                        .selectedLanguage)
-                                                .sentences
-                                                .manageTaskServerPageConfigureTaskRCDialogueBoxSelectTaskRC,
-                                            style: TextStyle(
-                                              color: AppSettings.isDarkMode
-                                                  ? TaskWarriorColors.white
-                                                  : TaskWarriorColors.black,
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
+                                      ),
+                                    ],
                                   ),
-                                ],
-                              ),
+                                );
+                              },
                             );
                           },
                         );
                       },
-                    );
-                  },
-                  child: Container(
-                    width: MediaQuery.of(context).size.width * 1,
-                    //   height: MediaQuery.of(context).size.height * 0.05,
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      // color: tileColor,
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: TaskWarriorColors.borderColor),
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          controller.taskrcContentController.text.isEmpty
-                              ? SentenceManager(
-                                      currentLanguage:
-                                          AppSettings.selectedLanguage)
-                                  .sentences
-                                  .manageTaskServerPageSetTaskRC
-                              : SentenceManager(
-                                      currentLanguage:
-                                          AppSettings.selectedLanguage)
-                                  .sentences
-                                  .manageTaskServerPageTaskRCFileIsVerified,
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
+                      child: Container(
+                        width: MediaQuery.of(context).size.width * 1,
+                        //   height: MediaQuery.of(context).size.height * 0.05,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          // color: tileColor,
+                          borderRadius: BorderRadius.circular(8),
+                          border:
+                              Border.all(color: TaskWarriorColors.borderColor),
                         ),
-                        Container(
-                          height: 30,
-                          width: 30,
-                          decoration: BoxDecoration(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors
-                                    .kLightSecondaryBackgroundColor
-                                : TaskWarriorColors.ksecondaryBackgroundColor,
-                            shape: BoxShape.circle,
-                          ),
-                          child: Center(
-                            child: controller
-                                    .taskrcContentController.text.isNotEmpty
-                                ? Icon(
-                                    Icons.check,
-                                    color: TaskWarriorColors.green,
-                                  )
-                                : Icon(
-                                    Icons.chevron_right_rounded,
-                                    color: AppSettings.isDarkMode
-                                        ? TaskWarriorColors.black
-                                        : TaskWarriorColors.white,
-                                  ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Offstage(
-              offstage: controller.isTaskDServerActive.value,
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      top: 10,
-                      bottom: 10,
-                    ),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          "TaskD Server Info",
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        const SizedBox(height: 10),
-                        GestureDetector(
-                          onTap: () {},
-                          child: Container(
-                            width: MediaQuery.of(context).size.width * 1,
-                            //   height: MediaQuery.of(context).size.height * 0.05,
-                            padding: const EdgeInsets.all(12),
-                            decoration: BoxDecoration(
-                              // color: tileColor,
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: TaskWarriorColors.borderColor,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              controller.taskrcContentController.text.isEmpty
+                                  ? SentenceManager(
+                                          currentLanguage:
+                                              AppSettings.selectedLanguage)
+                                      .sentences
+                                      .manageTaskServerPageSetTaskRC
+                                  : SentenceManager(
+                                          currentLanguage:
+                                              AppSettings.selectedLanguage)
+                                      .sentences
+                                      .manageTaskServerPageTaskRCFileIsVerified,
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
                               ),
                             ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                controller.server == null
-                                    ? Text(
-                                        'Not Configured',
-                                        style: TextStyle(
-                                          color: AppSettings.isDarkMode
-                                              ? TaskWarriorColors.white
-                                              : TaskWarriorColors.black,
-                                        ),
+                            Container(
+                              height: 30,
+                              width: 30,
+                              decoration: BoxDecoration(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors
+                                        .kLightSecondaryBackgroundColor
+                                    : TaskWarriorColors
+                                        .ksecondaryBackgroundColor,
+                                shape: BoxShape.circle,
+                              ),
+                              child: Center(
+                                child: controller
+                                        .taskrcContentController.text.isNotEmpty
+                                    ? Icon(
+                                        Icons.check,
+                                        color: TaskWarriorColors.green,
                                       )
-                                    : Text(
-                                        '${controller.server}',
-                                        style: TextStyle(
-                                          color: AppSettings.isDarkMode
-                                              ? TaskWarriorColors.white
-                                              : TaskWarriorColors.black,
-                                        ),
+                                    : Icon(
+                                        Icons.chevron_right_rounded,
+                                        color: AppSettings.isDarkMode
+                                            ? TaskWarriorColors.black
+                                            : TaskWarriorColors.white,
                                       ),
-                                Container(
-                                  height: 30,
-                                  width: 30,
-                                  decoration: BoxDecoration(
-                                    color: AppSettings.isDarkMode
-                                        ? TaskWarriorColors
-                                            .kLightSecondaryBackgroundColor
-                                        : TaskWarriorColors
-                                            .ksecondaryBackgroundColor,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: Center(
-                                    child: controller.server != null
-                                        ? Icon(
-                                            Icons.check,
-                                            color: TaskWarriorColors.green,
-                                          )
-                                        : Icon(
-                                            Icons.chevron_right_rounded,
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.black
-                                                : TaskWarriorColors.white,
-                                          ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Offstage(
+                  offstage: controller.isTaskDServerActive.value,
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: 10,
+                          bottom: 10,
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "TaskD Server Info",
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            GestureDetector(
+                              onTap: () {},
+                              child: Container(
+                                width: MediaQuery.of(context).size.width * 1,
+                                //   height: MediaQuery.of(context).size.height * 0.05,
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  // color: tileColor,
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: TaskWarriorColors.borderColor,
                                   ),
                                 ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      top: 10,
-                      bottom: 10,
-                    ),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          "TaskD Server Credentials",
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        const SizedBox(height: 10),
-                        GestureDetector(
-                          onTap: () {},
-                          child: Container(
-                            width: MediaQuery.of(context).size.width * 1,
-                            //   height: MediaQuery.of(context).size.height * 0.05,
-                            padding: const EdgeInsets.all(12),
-                            decoration: BoxDecoration(
-                              // color: tileColor,
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                  color: TaskWarriorColors.borderColor),
-                            ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                controller.credentialsString == null
-                                    ? Text(
-                                        'Not Configured',
-                                        style: TextStyle(
-                                          color: AppSettings.isDarkMode
-                                              ? TaskWarriorColors.white
-                                              : TaskWarriorColors.black,
-                                        ),
-                                      )
-                                    : SizedBox(
-                                        width:
-                                            MediaQuery.of(context).size.width *
-                                                0.7,
-                                        child: SingleChildScrollView(
-                                          scrollDirection: Axis.horizontal,
-                                          child: Text(
-                                            controller.credentialsString!.value,
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    controller.server == null
+                                        ? Text(
+                                            'Not Configured',
+                                            style: TextStyle(
+                                              color: AppSettings.isDarkMode
+                                                  ? TaskWarriorColors.white
+                                                  : TaskWarriorColors.black,
+                                            ),
+                                          )
+                                        : Text(
+                                            '${controller.server}',
                                             style: TextStyle(
                                               color: AppSettings.isDarkMode
                                                   ? TaskWarriorColors.white
                                                   : TaskWarriorColors.black,
                                             ),
                                           ),
-                                        ),
+                                    Container(
+                                      height: 30,
+                                      width: 30,
+                                      decoration: BoxDecoration(
+                                        color: AppSettings.isDarkMode
+                                            ? TaskWarriorColors
+                                                .kLightSecondaryBackgroundColor
+                                            : TaskWarriorColors
+                                                .ksecondaryBackgroundColor,
+                                        shape: BoxShape.circle,
                                       ),
-                                GestureDetector(
-                                  onTap: () {
-                                    controller.hideKey.value =
-                                        !controller.hideKey.value;
-                                  },
-                                  child: Container(
-                                    height: 30,
-                                    width: 30,
-                                    decoration: BoxDecoration(
-                                      color: AppSettings.isDarkMode
-                                          ? TaskWarriorColors
-                                              .kLightPrimaryBackgroundColor
-                                          : TaskWarriorColors
-                                              .kprimaryBackgroundColor,
-                                      shape: BoxShape.circle,
+                                      child: Center(
+                                        child: controller.server != null
+                                            ? Icon(
+                                                Icons.check,
+                                                color: TaskWarriorColors.green,
+                                              )
+                                            : Icon(
+                                                Icons.chevron_right_rounded,
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.black
+                                                    : TaskWarriorColors.white,
+                                              ),
+                                      ),
                                     ),
-                                    child: controller.credentials == null
-                                        ? Icon(
-                                            Icons.chevron_right_rounded,
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.black
-                                                : TaskWarriorColors.white,
-                                          )
-                                        : Icon(
-                                            controller.hideKey.value
-                                                ? Icons.visibility_off
-                                                : Icons.visibility,
-                                            color: AppSettings.isDarkMode
-                                                ? TaskWarriorColors.green
-                                                : TaskWarriorColors.green,
-                                          ),
-                                  ),
+                                  ],
                                 ),
-                              ],
+                              ),
                             ),
-                          ),
+                          ],
                         ),
-                      ],
-                    ),
-                  ),
-                ],
-              )),
-          GetBuilder<ManageTaskServerController>(
-            builder: (controller) {
-              List<Widget> pemWidgets = [];
-              for (var pem in [
-                'taskd.certificate',
-                'taskd.key',
-                'taskd.ca',
-                if (controller.homeController.serverCertExists.value)
-                  'server.cert',
-              ]) {
-                pemWidgets.add(
-                  PemWidget(
-                    storage: controller.storage,
-                    pem: pem,
-                    optionString: pem == "taskd.certificate"
-                        ? SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .manageTaskServerPageConfigureYourCertificate
-                        : pem == "taskd.key"
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: 10,
+                          bottom: 10,
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "TaskD Server Credentials",
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            GestureDetector(
+                              onTap: () {},
+                              child: Container(
+                                width: MediaQuery.of(context).size.width * 1,
+                                //   height: MediaQuery.of(context).size.height * 0.05,
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  // color: tileColor,
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                      color: TaskWarriorColors.borderColor),
+                                ),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    controller.credentialsString == null
+                                        ? Text(
+                                            'Not Configured',
+                                            style: TextStyle(
+                                              color: AppSettings.isDarkMode
+                                                  ? TaskWarriorColors.white
+                                                  : TaskWarriorColors.black,
+                                            ),
+                                          )
+                                        : SizedBox(
+                                            width: MediaQuery.of(context)
+                                                    .size
+                                                    .width *
+                                                0.7,
+                                            child: SingleChildScrollView(
+                                              scrollDirection: Axis.horizontal,
+                                              child: Text(
+                                                controller
+                                                    .credentialsString!.value,
+                                                style: TextStyle(
+                                                  color: AppSettings.isDarkMode
+                                                      ? TaskWarriorColors.white
+                                                      : TaskWarriorColors.black,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                    GestureDetector(
+                                      onTap: () {
+                                        controller.hideKey.value =
+                                            !controller.hideKey.value;
+                                      },
+                                      child: Container(
+                                        height: 30,
+                                        width: 30,
+                                        decoration: BoxDecoration(
+                                          color: AppSettings.isDarkMode
+                                              ? TaskWarriorColors
+                                                  .kLightPrimaryBackgroundColor
+                                              : TaskWarriorColors
+                                                  .kprimaryBackgroundColor,
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: controller.credentials == null
+                                            ? Icon(
+                                                Icons.chevron_right_rounded,
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.black
+                                                    : TaskWarriorColors.white,
+                                              )
+                                            : Icon(
+                                                controller.hideKey.value
+                                                    ? Icons.visibility_off
+                                                    : Icons.visibility,
+                                                color: AppSettings.isDarkMode
+                                                    ? TaskWarriorColors.green
+                                                    : TaskWarriorColors.green,
+                                              ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  )),
+              GetBuilder<ManageTaskServerController>(
+                builder: (controller) {
+                  List<Widget> pemWidgets = [];
+                  for (var pem in [
+                    'taskd.certificate',
+                    'taskd.key',
+                    'taskd.ca',
+                    if (controller.homeController.serverCertExists.value)
+                      'server.cert',
+                  ]) {
+                    pemWidgets.add(
+                      PemWidget(
+                        storage: controller.storage,
+                        pem: pem,
+                        optionString: pem == "taskd.certificate"
                             ? SentenceManager(
                                     currentLanguage:
                                         AppSettings.selectedLanguage)
                                 .sentences
-                                .manageTaskServerPageConfigureTaskserverKey
-                            : pem == "taskd.ca"
+                                .manageTaskServerPageConfigureYourCertificate
+                            : pem == "taskd.key"
                                 ? SentenceManager(
                                         currentLanguage:
                                             AppSettings.selectedLanguage)
                                     .sentences
-                                    .manageTaskServerPageConfigureServerCertificate
-                                : SentenceManager(
-                                        currentLanguage:
-                                            AppSettings.selectedLanguage)
-                                    .sentences
-                                    .manageTaskServerPageConfigureServerCertificate,
-                    listTileTitle: pem == "taskd.certificate"
-                        ? SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .manageTaskServerPageSelectCertificate
-                        : pem == "taskd.key"
+                                    .manageTaskServerPageConfigureTaskserverKey
+                                : pem == "taskd.ca"
+                                    ? SentenceManager(
+                                            currentLanguage:
+                                                AppSettings.selectedLanguage)
+                                        .sentences
+                                        .manageTaskServerPageConfigureServerCertificate
+                                    : SentenceManager(
+                                            currentLanguage:
+                                                AppSettings.selectedLanguage)
+                                        .sentences
+                                        .manageTaskServerPageConfigureServerCertificate,
+                        listTileTitle: pem == "taskd.certificate"
                             ? SentenceManager(
                                     currentLanguage:
                                         AppSettings.selectedLanguage)
                                 .sentences
-                                .manageTaskServerPageSelectKey
-                            : pem == "taskd.ca"
+                                .manageTaskServerPageSelectCertificate
+                            : pem == "taskd.key"
                                 ? SentenceManager(
                                         currentLanguage:
                                             AppSettings.selectedLanguage)
                                     .sentences
-                                    .manageTaskServerPageSelectCertificate
-                                : SentenceManager(
-                                        currentLanguage:
-                                            AppSettings.selectedLanguage)
-                                    .sentences
-                                    .manageTaskServerPageSelectCertificate,
-                    onTapCallBack: controller.onTapPEMWidget,
-                    onLongPressCallBack: controller.onLongPressPEMWidget,
-                    globalKey: controller.getGlobalKey(pem),
-                  ),
-                );
-              }
-              return Column(
-                children: pemWidgets,
-              );
-            },
-          )
-        ],
-      ),
-    );
+                                    .manageTaskServerPageSelectKey
+                                : pem == "taskd.ca"
+                                    ? SentenceManager(
+                                            currentLanguage:
+                                                AppSettings.selectedLanguage)
+                                        .sentences
+                                        .manageTaskServerPageSelectCertificate
+                                    : SentenceManager(
+                                            currentLanguage:
+                                                AppSettings.selectedLanguage)
+                                        .sentences
+                                        .manageTaskServerPageSelectCertificate,
+                        onTapCallBack: controller.onTapPEMWidget,
+                        onLongPressCallBack: controller.onLongPressPEMWidget,
+                        globalKey: controller.getGlobalKey(pem),
+                      ),
+                    );
+                  }
+                  return Column(
+                    children: pemWidgets,
+                  );
+                },
+              )
+            ],
+          ),
+        )));
   }
 }

--- a/lib/app/modules/profile/controllers/profile_controller.dart
+++ b/lib/app/modules/profile/controllers/profile_controller.dart
@@ -10,6 +10,8 @@ class ProfileController extends GetxController {
   var profilesWidget = Get.find<SplashController>();
   late RxMap<String, String?> profilesMap;
   late RxString currentProfile;
+  final RxBool isProfileTourActive = false.obs;
+
   @override
   void onInit() {
     profilesMap = profilesWidget.profilesMap;
@@ -37,6 +39,7 @@ class ProfileController extends GetxController {
       opacityShadow: 1.00,
       hideSkip: true,
       onFinish: () {
+        isProfileTourActive.value = false;
         SaveTourStatus.saveProfileTourStatus(true);
       },
     );
@@ -49,6 +52,7 @@ class ProfileController extends GetxController {
         SaveTourStatus.getProfileTourStatus().then((value) => {
               if (value == false)
                 {
+                  isProfileTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else

--- a/lib/app/modules/profile/views/profile_view.dart
+++ b/lib/app/modules/profile/views/profile_view.dart
@@ -23,196 +23,214 @@ class ProfileView extends GetView<ProfileController> {
   Widget build(BuildContext context) {
     controller.initProfilePageTour();
     controller.showProfilePageTour(context);
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Palette.kToDark.shade200,
-        title: Obx(() => Text(
-              controller.profilesMap.length == 1
-                  ? SentenceManager(
-                          currentLanguage: AppSettings.selectedLanguage)
-                      .sentences
-                      .profilePageProfile
-                  : SentenceManager(
-                          currentLanguage: AppSettings.selectedLanguage)
-                      .sentences
-                      .profilePageProfiles,
-              style: GoogleFonts.poppins(
+    return Obx(() => PopScope(
+        canPop: !controller.isProfileTourActive.value,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (controller.isProfileTourActive.value) {
+            Get.closeAllSnackbars();
+            Get.snackbar(
+              'Tour Active',
+              'Please complete the tour before navigating back.',
+              snackPosition: SnackPosition.BOTTOM,
+            );
+            return;
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            backgroundColor: Palette.kToDark.shade200,
+            title: Obx(() => Text(
+                  controller.profilesMap.length == 1
+                      ? SentenceManager(
+                              currentLanguage: AppSettings.selectedLanguage)
+                          .sentences
+                          .profilePageProfile
+                      : SentenceManager(
+                              currentLanguage: AppSettings.selectedLanguage)
+                          .sentences
+                          .profilePageProfiles,
+                  style: GoogleFonts.poppins(
+                    color: TaskWarriorColors.white,
+                  ),
+                )),
+            leading: IconButton(
+              onPressed: () {
+                // Navigator.pushReplacementNamed(context, PageRoutes.home);
+                // Navigator.of(context).pop();
+                Get.back();
+              },
+              icon: Icon(
+                Icons.chevron_left,
                 color: TaskWarriorColors.white,
+                size: 30,
               ),
-            )),
-        leading: IconButton(
-          onPressed: () {
-            // Navigator.pushReplacementNamed(context, PageRoutes.home);
-            // Navigator.of(context).pop();
-            Get.back();
-          },
-          icon: Icon(
-            Icons.chevron_left,
-            color: TaskWarriorColors.white,
-            size: 30,
+            ),
           ),
-        ),
-      ),
-      //primary: false,
-      backgroundColor: AppSettings.isDarkMode
-          ? TaskWarriorColors.kprimaryBackgroundColor
-          : TaskWarriorColors.kLightPrimaryBackgroundColor,
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            Obx(
-              () => ProfilesColumn(
-                currentProfileKey: controller.currentProfileKey,
-                addNewProfileKey: controller.addNewProfileKey,
-                manageSelectedProfileKey: controller.manageSelectedProfileKey,
-                controller.profilesMap,
-                controller.currentProfile.value,
-                controller.profilesWidget.addProfile,
-                controller.profilesWidget.selectProfile,
-                () => showDialog(
-                  context: context,
-                  builder: (context) => Center(
-                    child: RenameProfileDialog(
-                      profile: controller.currentProfile.value,
-                      alias: controller
-                          .profilesMap[controller.currentProfile.value],
+          //primary: false,
+          backgroundColor: AppSettings.isDarkMode
+              ? TaskWarriorColors.kprimaryBackgroundColor
+              : TaskWarriorColors.kLightPrimaryBackgroundColor,
+          body: SingleChildScrollView(
+            child: Column(
+              children: [
+                Obx(
+                  () => ProfilesColumn(
+                    currentProfileKey: controller.currentProfileKey,
+                    addNewProfileKey: controller.addNewProfileKey,
+                    manageSelectedProfileKey:
+                        controller.manageSelectedProfileKey,
+                    controller.profilesMap,
+                    controller.currentProfile.value,
+                    controller.profilesWidget.addProfile,
+                    controller.profilesWidget.selectProfile,
+                    () => showDialog(
                       context: context,
+                      builder: (context) => Center(
+                        child: RenameProfileDialog(
+                          profile: controller.currentProfile.value,
+                          alias: controller
+                              .profilesMap[controller.currentProfile.value],
+                          context: context,
+                        ),
+                      ),
+                    ),
+                    // () => Navigator.push(
+                    //   context,
+                    //   MaterialPageRoute(
+                    //     // builder: (_) => const ConfigureTaskserverRoute(),
+                    //     builder: (_) => const ManageTaskServerView(),
+                    //   ),
+                    // ),
+                    () => Get.toNamed(Routes.MANAGE_TASK_SERVER),
+                    () {
+                      var tasks = controller.profilesWidget
+                          .getStorage(controller.currentProfile.value)
+                          .data
+                          .export();
+                      var now = DateTime.now()
+                          .toIso8601String()
+                          .replaceAll(RegExp(r'[-:]'), '')
+                          .replaceAll(RegExp(r'\..*'), '');
+
+                      showDialog(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return Utils.showAlertDialog(
+                            title: Text(
+                              SentenceManager(
+                                      currentLanguage:
+                                          AppSettings.selectedLanguage)
+                                  .sentences
+                                  .profilePageExportTasksDialogueTitle,
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            content: Text(
+                              SentenceManager(
+                                      currentLanguage:
+                                          AppSettings.selectedLanguage)
+                                  .sentences
+                                  .profilePageExportTasksDialogueSubtitle,
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            actions: <Widget>[
+                              TextButton(
+                                child: Text(
+                                  "JSON",
+                                  style: TextStyle(
+                                    color: AppSettings.isDarkMode
+                                        ? TaskWarriorColors.white
+                                        : TaskWarriorColors.black,
+                                  ),
+                                ),
+                                onPressed: () {
+                                  // Navigator.of(context).pop();
+                                  Get.back();
+                                  exportTasks(
+                                    contents: tasks,
+                                    suggestedName: 'tasks-$now.json',
+                                  );
+                                },
+                              ),
+                              TextButton(
+                                child: Text(
+                                  "TXT",
+                                  style: TextStyle(
+                                    color: AppSettings.isDarkMode
+                                        ? TaskWarriorColors.white
+                                        : TaskWarriorColors.black,
+                                  ),
+                                ),
+                                onPressed: () {
+                                  // Navigator.of(context).pop();
+                                  Get.back();
+                                  exportTasks(
+                                    contents: tasks,
+                                    suggestedName: 'tasks-$now.txt',
+                                  );
+                                },
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    },
+                    () {
+                      try {
+                        controller.profilesWidget.copyConfigToNewProfile(
+                          controller.currentProfile.value,
+                        );
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                            content: Text(
+                              'Profile Config Copied',
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            backgroundColor: AppSettings.isDarkMode
+                                ? TaskWarriorColors.ksecondaryBackgroundColor
+                                : TaskWarriorColors
+                                    .kLightSecondaryBackgroundColor,
+                            duration: const Duration(seconds: 2)));
+                      } catch (e) {
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                            content: Text(
+                              'Profile Config Copy Failed',
+                              style: TextStyle(
+                                color: AppSettings.isDarkMode
+                                    ? TaskWarriorColors.white
+                                    : TaskWarriorColors.black,
+                              ),
+                            ),
+                            backgroundColor: AppSettings.isDarkMode
+                                ? TaskWarriorColors.ksecondaryBackgroundColor
+                                : TaskWarriorColors
+                                    .kLightSecondaryBackgroundColor,
+                            duration: const Duration(seconds: 2)));
+                      }
+                    },
+                    () => showDialog(
+                      context: context,
+                      builder: (context) => DeleteProfileDialog(
+                        profile: controller.currentProfile.value,
+                        context: context,
+                      ),
                     ),
                   ),
                 ),
-                // () => Navigator.push(
-                //   context,
-                //   MaterialPageRoute(
-                //     // builder: (_) => const ConfigureTaskserverRoute(),
-                //     builder: (_) => const ManageTaskServerView(),
-                //   ),
-                // ),
-                () => Get.toNamed(Routes.MANAGE_TASK_SERVER),
-                () {
-                  var tasks = controller.profilesWidget
-                      .getStorage(controller.currentProfile.value)
-                      .data
-                      .export();
-                  var now = DateTime.now()
-                      .toIso8601String()
-                      .replaceAll(RegExp(r'[-:]'), '')
-                      .replaceAll(RegExp(r'\..*'), '');
-
-                  showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return Utils.showAlertDialog(
-                        title: Text(
-                          SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .profilePageExportTasksDialogueTitle,
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        content: Text(
-                          SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .profilePageExportTasksDialogueSubtitle,
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        actions: <Widget>[
-                          TextButton(
-                            child: Text(
-                              "JSON",
-                              style: TextStyle(
-                                color: AppSettings.isDarkMode
-                                    ? TaskWarriorColors.white
-                                    : TaskWarriorColors.black,
-                              ),
-                            ),
-                            onPressed: () {
-                              // Navigator.of(context).pop();
-                              Get.back();
-                              exportTasks(
-                                contents: tasks,
-                                suggestedName: 'tasks-$now.json',
-                              );
-                            },
-                          ),
-                          TextButton(
-                            child: Text(
-                              "TXT",
-                              style: TextStyle(
-                                color: AppSettings.isDarkMode
-                                    ? TaskWarriorColors.white
-                                    : TaskWarriorColors.black,
-                              ),
-                            ),
-                            onPressed: () {
-                              // Navigator.of(context).pop();
-                              Get.back();
-                              exportTasks(
-                                contents: tasks,
-                                suggestedName: 'tasks-$now.txt',
-                              );
-                            },
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                },
-                () {
-                  try {
-                    controller.profilesWidget.copyConfigToNewProfile(
-                      controller.currentProfile.value,
-                    );
-                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                        content: Text(
-                          'Profile Config Copied',
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        backgroundColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.ksecondaryBackgroundColor
-                            : TaskWarriorColors.kLightSecondaryBackgroundColor,
-                        duration: const Duration(seconds: 2)));
-                  } catch (e) {
-                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                        content: Text(
-                          'Profile Config Copy Failed',
-                          style: TextStyle(
-                            color: AppSettings.isDarkMode
-                                ? TaskWarriorColors.white
-                                : TaskWarriorColors.black,
-                          ),
-                        ),
-                        backgroundColor: AppSettings.isDarkMode
-                            ? TaskWarriorColors.ksecondaryBackgroundColor
-                            : TaskWarriorColors.kLightSecondaryBackgroundColor,
-                        duration: const Duration(seconds: 2)));
-                  }
-                },
-                () => showDialog(
-                  context: context,
-                  builder: (context) => DeleteProfileDialog(
-                    profile: controller.currentProfile.value,
-                    context: context,
-                  ),
-                ),
-              ),
+              ],
             ),
-          ],
-        ),
-      ),
-    );
+          ),
+        )));
   }
 }
 
@@ -325,11 +343,9 @@ class ProfilesColumn extends StatelessWidget {
                     ? TaskWarriorColors.deepPurpleAccent
                     : TaskWarriorColors.deepPurple),
             label: Text(
-              SentenceManager(
-                          currentLanguage: AppSettings.selectedLanguage)
-                      .sentences
-                      .profilePageAddNewProfile,
-
+              SentenceManager(currentLanguage: AppSettings.selectedLanguage)
+                  .sentences
+                  .profilePageAddNewProfile,
               style: TextStyle(
                 color: AppSettings.isDarkMode
                     ? TaskWarriorColors.white

--- a/lib/app/modules/reports/controllers/reports_controller.dart
+++ b/lib/app/modules/reports/controllers/reports_controller.dart
@@ -30,6 +30,7 @@ class ReportsController extends GetxController
   late TaskDatabase taskDatabase;
   var isSaved = false.obs;
   late TutorialCoachMark tutorialCoachMark;
+  final RxBool isReportsTourActive = false.obs;
 
   var selectedIndex = 0.obs;
   var allData = <Task>[].obs;
@@ -147,6 +148,7 @@ class ReportsController extends GetxController
       opacityShadow: 0.8,
       hideSkip: true,
       onFinish: () {
+        isReportsTourActive.value = false;
         SaveTourStatus.saveReportsTourStatus(true);
       },
     );
@@ -159,6 +161,7 @@ class ReportsController extends GetxController
         SaveTourStatus.getReportsTourStatus().then((value) => {
               if (value == false)
                 {
+                  isReportsTourActive.value = true,
                   tutorialCoachMark.show(context: context),
                 }
               else

--- a/lib/app/modules/reports/views/reports_view.dart
+++ b/lib/app/modules/reports/views/reports_view.dart
@@ -21,141 +21,156 @@ class ReportsView extends GetView<ReportsController> {
     controller.showReportsTour(context);
     double height = MediaQuery.of(context).size.height;
 
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: TaskWarriorColors.kprimaryBackgroundColor,
-        title: Text(
-          SentenceManager(currentLanguage: AppSettings.selectedLanguage)
-              .sentences
-              .reportsPageTitle,
-          style: GoogleFonts.poppins(color: TaskWarriorColors.white),
-        ),
-        leading: GestureDetector(
-          onTap: () {
-            Get.back();
-          },
-          child: Icon(
-            Icons.chevron_left,
-            color: TaskWarriorColors.white,
-          ),
-        ),
-        bottom: PreferredSize(
-          preferredSize: Size.fromHeight(height * 0.1),
-          child: TabBar(
-            controller: controller.tabController,
-            labelColor: TaskWarriorColors.white,
-            labelStyle: GoogleFonts.poppins(
-              fontWeight: TaskWarriorFonts.medium,
-              fontSize: TaskWarriorFonts.fontSizeSmall,
+    return Obx(() => PopScope(
+        canPop: !controller.isReportsTourActive.value,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (controller.isReportsTourActive.value) {
+            Get.closeAllSnackbars();
+            Get.snackbar(
+              'Tour Active',
+              'Please complete the tour before navigating back.',
+              snackPosition: SnackPosition.BOTTOM,
+            );
+            return;
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            backgroundColor: TaskWarriorColors.kprimaryBackgroundColor,
+            title: Text(
+              SentenceManager(currentLanguage: AppSettings.selectedLanguage)
+                  .sentences
+                  .reportsPageTitle,
+              style: GoogleFonts.poppins(color: TaskWarriorColors.white),
             ),
-            unselectedLabelStyle: GoogleFonts.poppins(
-              fontWeight: TaskWarriorFonts.light,
+            leading: GestureDetector(
+              onTap: () {
+                Get.back();
+              },
+              child: Icon(
+                Icons.chevron_left,
+                color: TaskWarriorColors.white,
+              ),
             ),
-            onTap: (value) {
-              controller.selectedIndex.value = value;
-            },
-            tabs: <Widget>[
-              Tab(
-                key: controller.daily,
-                icon: const Icon(Icons.schedule),
-                text: SentenceManager(
-                        currentLanguage: AppSettings.selectedLanguage)
-                    .sentences
-                    .reportsPageDaily,
-                iconMargin: const EdgeInsets.only(bottom: 0.0),
-              ),
-              Tab(
-                key: controller.weekly,
-                icon: const Icon(Icons.today),
-                text: SentenceManager(
-                        currentLanguage: AppSettings.selectedLanguage)
-                    .sentences
-                    .reportsPageWeekly,
-                iconMargin: const EdgeInsets.only(bottom: 0.0),
-              ),
-              Tab(
-                key: controller.monthly,
-                icon: const Icon(Icons.date_range),
-                text: SentenceManager(
-                        currentLanguage: AppSettings.selectedLanguage)
-                    .sentences
-                    .reportsPageMonthly,
-                iconMargin: const EdgeInsets.only(bottom: 0.0),
-              ),
-            ],
-          ),
-        ),
-      ),
-      backgroundColor: AppSettings.isDarkMode
-          ? TaskWarriorColors.kprimaryBackgroundColor
-          : TaskWarriorColors.white,
-      body: Obx(
-        () => controller.allData.isEmpty
-            ? Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.heart_broken,
-                    color: AppSettings.isDarkMode
-                        ? TaskWarriorColors.white
-                        : TaskWarriorColors.black,
+            bottom: PreferredSize(
+              preferredSize: Size.fromHeight(height * 0.1),
+              child: TabBar(
+                controller: controller.tabController,
+                labelColor: TaskWarriorColors.white,
+                labelStyle: GoogleFonts.poppins(
+                  fontWeight: TaskWarriorFonts.medium,
+                  fontSize: TaskWarriorFonts.fontSizeSmall,
+                ),
+                unselectedLabelStyle: GoogleFonts.poppins(
+                  fontWeight: TaskWarriorFonts.light,
+                ),
+                onTap: (value) {
+                  controller.selectedIndex.value = value;
+                },
+                tabs: <Widget>[
+                  Tab(
+                    key: controller.daily,
+                    icon: const Icon(Icons.schedule),
+                    text: SentenceManager(
+                            currentLanguage: AppSettings.selectedLanguage)
+                        .sentences
+                        .reportsPageDaily,
+                    iconMargin: const EdgeInsets.only(bottom: 0.0),
                   ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .reportsPageNoTasksFound,
-                        style: TextStyle(
-                          fontFamily: FontFamily.poppins,
-                          fontWeight: TaskWarriorFonts.medium,
-                          fontSize: TaskWarriorFonts.fontSizeSmall,
-                          color: AppSettings.isDarkMode
-                              ? TaskWarriorColors.white
-                              : TaskWarriorColors.black,
-                        ),
-                      ),
-                    ],
+                  Tab(
+                    key: controller.weekly,
+                    icon: const Icon(Icons.today),
+                    text: SentenceManager(
+                            currentLanguage: AppSettings.selectedLanguage)
+                        .sentences
+                        .reportsPageWeekly,
+                    iconMargin: const EdgeInsets.only(bottom: 0.0),
                   ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        SentenceManager(
-                                currentLanguage: AppSettings.selectedLanguage)
-                            .sentences
-                            .reportsPageAddTasksToSeeReports,
-                        style: TextStyle(
-                          fontFamily: FontFamily.poppins,
-                          fontWeight: TaskWarriorFonts.light,
-                          fontSize: TaskWarriorFonts.fontSizeSmall,
-                          color: AppSettings.isDarkMode
-                              ? TaskWarriorColors.white
-                              : TaskWarriorColors.black,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              )
-            : IndexedStack(
-                index: controller.selectedIndex.value,
-                children: [
-                  BurnDownDaily(
-                    reportsController: controller,
-                  ),
-                  BurnDownWeekly(
-                    reportsController: controller,
-                  ),
-                  BurnDownMonthly(
-                    reportsController: controller,
+                  Tab(
+                    key: controller.monthly,
+                    icon: const Icon(Icons.date_range),
+                    text: SentenceManager(
+                            currentLanguage: AppSettings.selectedLanguage)
+                        .sentences
+                        .reportsPageMonthly,
+                    iconMargin: const EdgeInsets.only(bottom: 0.0),
                   ),
                 ],
               ),
-      ),
-    );
+            ),
+          ),
+          backgroundColor: AppSettings.isDarkMode
+              ? TaskWarriorColors.kprimaryBackgroundColor
+              : TaskWarriorColors.white,
+          body: Obx(
+            () => controller.allData.isEmpty
+                ? Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.heart_broken,
+                        color: AppSettings.isDarkMode
+                            ? TaskWarriorColors.white
+                            : TaskWarriorColors.black,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            SentenceManager(
+                                    currentLanguage:
+                                        AppSettings.selectedLanguage)
+                                .sentences
+                                .reportsPageNoTasksFound,
+                            style: TextStyle(
+                              fontFamily: FontFamily.poppins,
+                              fontWeight: TaskWarriorFonts.medium,
+                              fontSize: TaskWarriorFonts.fontSizeSmall,
+                              color: AppSettings.isDarkMode
+                                  ? TaskWarriorColors.white
+                                  : TaskWarriorColors.black,
+                            ),
+                          ),
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            SentenceManager(
+                                    currentLanguage:
+                                        AppSettings.selectedLanguage)
+                                .sentences
+                                .reportsPageAddTasksToSeeReports,
+                            style: TextStyle(
+                              fontFamily: FontFamily.poppins,
+                              fontWeight: TaskWarriorFonts.light,
+                              fontSize: TaskWarriorFonts.fontSizeSmall,
+                              color: AppSettings.isDarkMode
+                                  ? TaskWarriorColors.white
+                                  : TaskWarriorColors.black,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  )
+                : IndexedStack(
+                    index: controller.selectedIndex.value,
+                    children: [
+                      BurnDownDaily(
+                        reportsController: controller,
+                      ),
+                      BurnDownWeekly(
+                        reportsController: controller,
+                      ),
+                      BurnDownMonthly(
+                        reportsController: controller,
+                      ),
+                    ],
+                  ),
+          ),
+        )));
   }
 }

--- a/lib/app/modules/reports/views/reports_view_taskc.dart
+++ b/lib/app/modules/reports/views/reports_view_taskc.dart
@@ -32,119 +32,132 @@ class ReportsHomeTaskc extends StatelessWidget {
       builder: (context, snapshot) {
         List<Tasks> allTasks = snapshot.data ?? [];
 
-        return Scaffold(
-          appBar: AppBar(
-            backgroundColor: TaskWarriorColors.kprimaryBackgroundColor,
-            title: Text(
-              'Reports',
-              style: GoogleFonts.poppins(color: TaskWarriorColors.white),
-            ),
-            leading: GestureDetector(
-              onTap: () {
-                Navigator.pop(context);
-              },
-              child: Icon(
-                Icons.chevron_left,
-                color: TaskWarriorColors.white,
-              ),
-            ),
-            bottom: PreferredSize(
-              preferredSize: Size.fromHeight(height * 0.1),
-              child: TabBar(
-                controller: reportsController.tabController,
-                labelColor: TaskWarriorColors.white,
-                labelStyle: GoogleFonts.poppins(
-                  fontWeight: TaskWarriorFonts.medium,
-                  fontSize: TaskWarriorFonts.fontSizeSmall,
+        return Obx(() => PopScope(
+            canPop: !reportsController.isReportsTourActive.value,
+            onPopInvokedWithResult: (didPop, result) async {
+              if (reportsController.isReportsTourActive.value) {
+                Get.closeAllSnackbars();
+                Get.snackbar(
+                  'Tour Active',
+                  'Please complete the tour before navigating back.',
+                  snackPosition: SnackPosition.BOTTOM,
+                );
+                return;
+              }
+            },
+            child: Scaffold(
+              appBar: AppBar(
+                backgroundColor: TaskWarriorColors.kprimaryBackgroundColor,
+                title: Text(
+                  'Reports',
+                  style: GoogleFonts.poppins(color: TaskWarriorColors.white),
                 ),
-                unselectedLabelStyle: GoogleFonts.poppins(
-                  fontWeight: TaskWarriorFonts.light,
+                leading: GestureDetector(
+                  onTap: () {
+                    Navigator.pop(context);
+                  },
+                  child: Icon(
+                    Icons.chevron_left,
+                    color: TaskWarriorColors.white,
+                  ),
                 ),
-                onTap: (value) {
-                  reportsController.selectedIndex.value = value;
-                },
-                tabs: <Widget>[
-                  Tab(
-                    key: reportsController.daily,
-                    icon: const Icon(Icons.schedule),
-                    text: 'Daily',
-                    iconMargin: const EdgeInsets.only(bottom: 0.0),
-                  ),
-                  Tab(
-                    key: reportsController.weekly,
-                    icon: const Icon(Icons.today),
-                    text: 'Weekly',
-                    iconMargin: const EdgeInsets.only(bottom: 0.0),
-                  ),
-                  Tab(
-                    key: reportsController.monthly,
-                    icon: const Icon(Icons.date_range),
-                    text: 'Monthly',
-                    iconMargin: const EdgeInsets.only(bottom: 0.0),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          backgroundColor: AppSettings.isDarkMode
-              ? TaskWarriorColors.kprimaryBackgroundColor
-              : TaskWarriorColors.white,
-          body: snapshot.connectionState == ConnectionState.waiting
-              ? const Center(child: CircularProgressIndicator())
-              : allTasks.isEmpty
-                  ? Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.heart_broken,
-                          color: AppSettings.isDarkMode
-                              ? TaskWarriorColors.white
-                              : TaskWarriorColors.black,
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              'No Task found',
-                              style: GoogleFonts.poppins(
-                                fontWeight: TaskWarriorFonts.medium,
-                                fontSize: TaskWarriorFonts.fontSizeSmall,
-                                color: AppSettings.isDarkMode
-                                    ? TaskWarriorColors.white
-                                    : TaskWarriorColors.black,
-                              ),
-                            ),
-                          ],
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              'Add a task to see reports',
-                              style: GoogleFonts.poppins(
-                                fontWeight: TaskWarriorFonts.light,
-                                fontSize: TaskWarriorFonts.fontSizeSmall,
-                                color: AppSettings.isDarkMode
-                                    ? TaskWarriorColors.white
-                                    : TaskWarriorColors.black,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    )
-                  : Obx(
-                      () => IndexedStack(
-                        index: reportsController.selectedIndex.value,
-                        children: [
-                          BurnDownDailyTaskc(),
-                          BurnDownWeeklyTask(),
-                          BurnDownMonthlyTaskc(),
-                        ],
-                      ),
+                bottom: PreferredSize(
+                  preferredSize: Size.fromHeight(height * 0.1),
+                  child: TabBar(
+                    controller: reportsController.tabController,
+                    labelColor: TaskWarriorColors.white,
+                    labelStyle: GoogleFonts.poppins(
+                      fontWeight: TaskWarriorFonts.medium,
+                      fontSize: TaskWarriorFonts.fontSizeSmall,
                     ),
-        );
+                    unselectedLabelStyle: GoogleFonts.poppins(
+                      fontWeight: TaskWarriorFonts.light,
+                    ),
+                    onTap: (value) {
+                      reportsController.selectedIndex.value = value;
+                    },
+                    tabs: <Widget>[
+                      Tab(
+                        key: reportsController.daily,
+                        icon: const Icon(Icons.schedule),
+                        text: 'Daily',
+                        iconMargin: const EdgeInsets.only(bottom: 0.0),
+                      ),
+                      Tab(
+                        key: reportsController.weekly,
+                        icon: const Icon(Icons.today),
+                        text: 'Weekly',
+                        iconMargin: const EdgeInsets.only(bottom: 0.0),
+                      ),
+                      Tab(
+                        key: reportsController.monthly,
+                        icon: const Icon(Icons.date_range),
+                        text: 'Monthly',
+                        iconMargin: const EdgeInsets.only(bottom: 0.0),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              backgroundColor: AppSettings.isDarkMode
+                  ? TaskWarriorColors.kprimaryBackgroundColor
+                  : TaskWarriorColors.white,
+              body: snapshot.connectionState == ConnectionState.waiting
+                  ? const Center(child: CircularProgressIndicator())
+                  : allTasks.isEmpty
+                      ? Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.heart_broken,
+                              color: AppSettings.isDarkMode
+                                  ? TaskWarriorColors.white
+                                  : TaskWarriorColors.black,
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  'No Task found',
+                                  style: GoogleFonts.poppins(
+                                    fontWeight: TaskWarriorFonts.medium,
+                                    fontSize: TaskWarriorFonts.fontSizeSmall,
+                                    color: AppSettings.isDarkMode
+                                        ? TaskWarriorColors.white
+                                        : TaskWarriorColors.black,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  'Add a task to see reports',
+                                  style: GoogleFonts.poppins(
+                                    fontWeight: TaskWarriorFonts.light,
+                                    fontSize: TaskWarriorFonts.fontSizeSmall,
+                                    color: AppSettings.isDarkMode
+                                        ? TaskWarriorColors.white
+                                        : TaskWarriorColors.black,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        )
+                      : Obx(
+                          () => IndexedStack(
+                            index: reportsController.selectedIndex.value,
+                            children: [
+                              BurnDownDailyTaskc(),
+                              BurnDownWeeklyTask(),
+                              BurnDownMonthlyTaskc(),
+                            ],
+                          ),
+                        ),
+            )));
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,14 +289,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  double_back_to_close_app:
-    dependency: "direct main"
-    description:
-      name: double_back_to_close_app
-      sha256: d19ce4e2f8d2cb9f35bdbc90eecd5c731cc0e6216f5e8f14e7d1e076dafb344a
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   crypto: ^3.0.1
   cupertino_icons: ^1.0.5
   date_format: ^2.0.6
-  double_back_to_close_app: ^2.1.0
   file_picker: ^9.0.2
   file_picker_writable:
     git:


### PR DESCRIPTION
# Description

- I have fixed the bug where the page or widget is popped out of context while the tour or tutorial is still going on. Have used `PopScope` to handle it.
- Fixed the details page update bug where it forces user to push `Yes` in save changes dialog box to go back to home page.
- Also removed third party dependency `double_back_to_close_app` and simulated the double back to exit in home page using `PopScope`

Refer to the issues for more detail on the bug

## Fixes #469 and #471 

## Screenshots / Videos

### Tutorial bug fix:
![image](https://github.com/user-attachments/assets/4d64b586-72da-4b15-8e24-8129f74f89ff)
![image](https://github.com/user-attachments/assets/4328c87e-7ba8-4d76-b64b-19b48a0967ab)
![image](https://github.com/user-attachments/assets/4537f172-1271-48ed-af25-f523979637ba)

### Details page fix:

https://github.com/user-attachments/assets/a8573c3d-af2e-410b-b295-38be42219e6b

---

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing