### PR TITLE
Fix: added entitlements in Release.entitlements for networking and file access for macOS

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,7 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

This PR adds missing macOS entitlements to Release.entitlements that were already present in DebugProfile.entitlements

These entitlements are required for:
- Allowing users to access/download files and pick directories
- Syncing over the net

### Added:
- com.apple.security.network.client
- com.apple.security.network.server
- com.apple.security.files.user-selected.read-write

### Before (Issue Demonstration):
https://github.com/user-attachments/assets/904652e0-97fe-4f8d-8fa9-2c0827b470cd

### After (Functioning Build):
https://github.com/user-attachments/assets/183369a7-0dee-4dd8-bdca-d5ad51e6b052

File picker and network access now function as expected while testing locally using flutter build macos