### PR TITLE
feat: highlight overdue tasks

### DIFF
--- a/lib/app/modules/home/views/tas_list_item.dart
+++ b/lib/app/modules/home/views/tas_list_item.dart
@@ -56,7 +56,13 @@ class TaskListItem extends StatelessWidget {
     bool isDueWithinOneDay(DateTime dueDate) {
       DateTime now = DateTime.now();
       Duration difference = dueDate.difference(now);
-      return difference.inDays <= 1 && difference.inDays >= 0;
+      return difference.inDays < 1 && difference.inMicroseconds > 0;
+    }
+
+    bool isOverDue(DateTime dueDate) {
+      DateTime now = DateTime.now();
+      Duration difference = dueDate.difference(now);
+      return difference.inMicroseconds < 0;
     }
 
     MaterialColor colours = Colors.grey;
@@ -86,6 +92,11 @@ class TaskListItem extends StatelessWidget {
                 : dimColor, // Set default border color
           ),
           borderRadius: BorderRadius.circular(8.0),
+          color: (task.due != null && isOverDue(task.due!) && useDelayTask)
+              ? Colors.red.withAlpha(50)
+              : AppSettings.isDarkMode
+                  ? TaskWarriorColors.ksecondaryBackgroundColor
+                  : TaskWarriorColors.kLightSecondaryBackgroundColor,
         ),
         child: ListTile(
           title: Row(

--- a/lib/app/utils/language/bengali_sentences.dart
+++ b/lib/app/utils/language/bengali_sentences.dart
@@ -52,11 +52,10 @@ class BengaliSentences extends Sentences {
   String get settingsPageEnableSyncOnTaskCreateDescription =>
       'নতুন টাস্ক তৈরি করার সময় স্বয়ংক্রিয় সিঙ্কিং সক্ষম করুন';
   @override
-  String get settingsPageHighlightTaskTitle =>
-      'শুধু 1 দিন বাকি থাকলে টাস্ক হাইলাইট করুন';
+  String get settingsPageHighlightTaskTitle => 'জরুরি টাস্ক হাইলাইট করুন';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'শুধু 1 দিন বাকি থাকলে টাস্ক হাইলাইট করুন';
+      '1 দিনের মধ্যে বা অতিক্রান্ত সময়ের টাস্ক হাইলাইট করুন';
   @override
   String get settingsPageEnable24hrFormatTitle =>
       '24 ঘণ্টার ফর্ম্যাট সক্রিয় করুন';

--- a/lib/app/utils/language/english_sentences.dart
+++ b/lib/app/utils/language/english_sentences.dart
@@ -53,10 +53,10 @@ class EnglishSentences extends Sentences {
   String get settingsPageEnableSyncOnTaskCreateDescription =>
       'Enable automatic syncing when creating a new task';
   @override
-  String get settingsPageHighlightTaskTitle => 'Highlight the task';
+  String get settingsPageHighlightTaskTitle => 'Highlight urgent tasks';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'Make the border of task if only 1 day left';
+      'Highlight tasks due within 1 day or already overdue';
   @override
   String get settingsPageEnable24hrFormatTitle => 'Enable 24 hr format';
   @override

--- a/lib/app/utils/language/french_sentences.dart
+++ b/lib/app/utils/language/french_sentences.dart
@@ -52,11 +52,10 @@ class FrenchSentences extends Sentences {
   String get settingsPageEnableSyncOnTaskCreateDescription =>
       'Activer la synchronisation automatique lors de la création de nouvelles tâches';
   @override
-  String get settingsPageHighlightTaskTitle =>
-      'Surbrillance des tâches avec 1 jour restant';
+  String get settingsPageHighlightTaskTitle => 'Surligner les tâches urgentes';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'Surbrillance des tâches avec 1 jour restant';
+      'Surligner les tâches dues dans 1 jour ou en retard';
   @override
   String get settingsPageEnable24hrFormatTitle => 'Activer le format 24 heures';
   @override

--- a/lib/app/utils/language/hindi_sentences.dart
+++ b/lib/app/utils/language/hindi_sentences.dart
@@ -52,11 +52,10 @@ class HindiSentences extends Sentences {
   String get settingsPageEnableSyncOnTaskCreateDescription =>
       'नई टास्क बनाते समय स्वचालित सिंकिंग सक्षम करें';
   @override
-  String get settingsPageHighlightTaskTitle =>
-      'केवल 1 दिन शेष होने पर कार्य की सीमा बनाएं';
+  String get settingsPageHighlightTaskTitle => 'तत्काल कार्यों को हाइलाइट करें';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'केवल 1 दिन शेष होने पर कार्य की सीमा बनाएं';
+      '1 दिन के भीतर देय या अतिदेय कार्यों को हाइलाइट करें';
   @override
   String get settingsPageEnable24hrFormatTitle =>
       '24 घंटे का प्रारूप सक्षम करें';

--- a/lib/app/utils/language/marathi_sentences.dart
+++ b/lib/app/utils/language/marathi_sentences.dart
@@ -53,10 +53,10 @@ class MarathiSentences extends Sentences {
       'नवीन कार्य तयार करताना स्वयंसिंकिंग सक्षम करा';
   @override
   String get settingsPageHighlightTaskTitle =>
-      'फक्त 1 दिवस शेष असताना कार्याची सीमा बनवा';
+      'तातडीच्या कार्यांना हायलाईट करा';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'फक्त 1 दिवस शेष असताना कार्याची सीमा बनवा';
+      '1 दिवसाच्या आत देय किंवा मुदत संपलेल्या कार्यांना हायलाईट करा';
   @override
   String get settingsPageEnable24hrFormatTitle => '24 तासाचा स्वरूप सक्षम करा';
   @override

--- a/lib/app/utils/language/spanish_sentences.dart
+++ b/lib/app/utils/language/spanish_sentences.dart
@@ -53,11 +53,10 @@ class SpanishSentences extends Sentences {
   String get settingsPageEnableSyncOnTaskCreateDescription =>
       'Habilitar sincronización automática al crear nuevas tareas';
   @override
-  String get settingsPageHighlightTaskTitle =>
-      'Resaltar tareas con 1 día restante';
+  String get settingsPageHighlightTaskTitle => 'Resaltar tareas urgentes';
   @override
   String get settingsPageHighlightTaskDescription =>
-      'Resaltar tareas con 1 día restante';
+      'Resaltar tareas que vencen en 1 día o están vencidas';
   @override
   String get settingsPageEnable24hrFormatTitle =>
       'Habilitar formato de 24 horas';

--- a/test/modules/home/task_list_item_test.dart
+++ b/test/modules/home/task_list_item_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:taskwarrior/app/models/json/task.dart';
+import 'package:taskwarrior/app/modules/home/views/tas_list_item.dart';
+import 'package:taskwarrior/app/utils/language/supported_language.dart';
+import 'package:taskwarrior/app/utils/taskfunctions/modify.dart';
+
+class MockModify extends Mock implements Modify {}
+
+void main() {
+  group('TaskListItem', () {
+    late Task normalTask;
+    late Task dueSoonTask;
+    late Task overdueTask;
+    late MockModify mockModify;
+
+    setUp(() {
+      mockModify = MockModify();
+
+      normalTask = Task((b) => b
+        ..id = 1
+        ..uuid = 'uuid1'
+        ..description = 'Task without urgency'
+        ..status = 'pending'
+        ..entry = DateTime.now()
+        ..due = DateTime.now().add(const Duration(days: 5)));
+
+      dueSoonTask = Task((b) => b
+        ..id = 2
+        ..uuid = 'uuid2'
+        ..description = 'Task due soon'
+        ..status = 'pending'
+        ..entry = DateTime.now()
+        ..due = DateTime.now().add(const Duration(hours: 23)));
+
+      overdueTask = Task((b) => b
+        ..id = 3
+        ..uuid = 'uuid3'
+        ..description = 'Overdue task'
+        ..status = 'pending'
+        ..entry = DateTime.now()
+        ..due = DateTime.now().subtract(const Duration(days: 1)));
+    });
+
+    testWidgets('renders normal task without highlight',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TaskListItem(
+            normalTask,
+            darkmode: false,
+            useDelayTask: true,
+            modify: mockModify,
+            selectedLanguage: SupportedLanguage.english,
+          ),
+        ),
+      ));
+
+      expect(find.text('1. Task without urgency'), findsOneWidget);
+
+      final containerFinder = find.byType(Container).first;
+      final Container container = tester.widget(containerFinder);
+      final BoxDecoration decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, isNot(Colors.red));
+      expect((decoration.color as Color).alpha, isNot(50));
+    });
+
+    testWidgets('renders due soon task with red border',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TaskListItem(
+            dueSoonTask,
+            darkmode: false,
+            useDelayTask: true,
+            modify: mockModify,
+            selectedLanguage: SupportedLanguage.english,
+          ),
+        ),
+      ));
+
+      expect(find.text('2. Task due soon'), findsOneWidget);
+
+      final containerFinder = find.byType(Container).first;
+      final Container container = tester.widget(containerFinder);
+      final BoxDecoration decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.red);
+    });
+
+    testWidgets('renders overdue task with red background',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TaskListItem(
+            overdueTask,
+            darkmode: false,
+            useDelayTask: true,
+            modify: mockModify,
+            selectedLanguage: SupportedLanguage.english,
+          ),
+        ),
+      ));
+
+      expect(find.text('3. Overdue task'), findsOneWidget);
+
+      final containerFinder = find.byType(Container).first;
+      final Container container = tester.widget(containerFinder);
+      final BoxDecoration decoration = container.decoration as BoxDecoration;
+      expect((decoration.color as Color).red, Colors.red.red);
+      expect((decoration.color as Color).alpha, 50);
+    });
+
+    testWidgets('does not highlight tasks when useDelayTask is false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TaskListItem(
+            overdueTask,
+            darkmode: false,
+            useDelayTask: false,
+            modify: mockModify,
+            selectedLanguage: SupportedLanguage.english,
+          ),
+        ),
+      ));
+
+      expect(find.text('3. Overdue task'), findsOneWidget);
+
+      final containerFinder = find.byType(Container).first;
+      final Container container = tester.widget(containerFinder);
+      final BoxDecoration decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, isNot(Colors.red));
+      expect((decoration.color as Color).alpha, isNot(50));
+    });
+  });
+}

--- a/test/utils/language/bengali_sentences_test.dart
+++ b/test/utils/language/bengali_sentences_test.dart
@@ -33,10 +33,9 @@ void main() {
         'নতুন টাস্ক তৈরি করার সময় স্বয়ংক্রিয় সিঙ্কিং সক্ষম করুন');
     expect(bengali.settingsPageEnableSyncOnTaskCreateDescription,
         'নতুন টাস্ক তৈরি করার সময় স্বয়ংক্রিয় সিঙ্কিং সক্ষম করুন');
-    expect(bengali.settingsPageHighlightTaskTitle,
-        'শুধু 1 দিন বাকি থাকলে টাস্ক হাইলাইট করুন');
+    expect(bengali.settingsPageHighlightTaskTitle, 'জরুরি টাস্ক হাইলাইট করুন');
     expect(bengali.settingsPageHighlightTaskDescription,
-        'শুধু 1 দিন বাকি থাকলে টাস্ক হাইলাইট করুন');
+        '1 দিনের মধ্যে বা অতিক্রান্ত সময়ের টাস্ক হাইলাইট করুন');
     expect(bengali.settingsPageEnable24hrFormatTitle,
         '24 ঘণ্টার ফর্ম্যাট সক্রিয় করুন');
     expect(bengali.settingsPageEnable24hrFormatDescription,

--- a/test/utils/language/english_sentences_test.dart
+++ b/test/utils/language/english_sentences_test.dart
@@ -33,9 +33,9 @@ void main() {
         english.settingsPageEnableSyncOnTaskCreateTitle, 'Sync on task create');
     expect(english.settingsPageEnableSyncOnTaskCreateDescription,
         'Enable automatic syncing when creating a new task');
-    expect(english.settingsPageHighlightTaskTitle, 'Highlight the task');
+    expect(english.settingsPageHighlightTaskTitle, 'Highlight urgent tasks');
     expect(english.settingsPageHighlightTaskDescription,
-        'Make the border of task if only 1 day left');
+        'Highlight tasks due within 1 day or already overdue');
     expect(english.settingsPageEnable24hrFormatTitle, 'Enable 24 hr format');
     expect(english.settingsPageEnable24hrFormatDescription,
         'Switch right to enable 24 hr format');

--- a/test/utils/language/french_sentences_test.dart
+++ b/test/utils/language/french_sentences_test.dart
@@ -33,10 +33,10 @@ void main() {
         'Activer la synchronisation automatique lors de la création de nouvelles tâches');
     expect(french.settingsPageEnableSyncOnTaskCreateDescription,
         'Activer la synchronisation automatique lors de la création de nouvelles tâches');
-    expect(french.settingsPageHighlightTaskTitle,
-        'Surbrillance des tâches avec 1 jour restant');
+    expect(
+        french.settingsPageHighlightTaskTitle, 'Surligner les tâches urgentes');
     expect(french.settingsPageHighlightTaskDescription,
-        'Surbrillance des tâches avec 1 jour restant');
+        'Surligner les tâches dues dans 1 jour ou en retard');
     expect(french.settingsPageEnable24hrFormatTitle,
         'Activer le format 24 heures');
     expect(french.settingsPageEnable24hrFormatDescription,

--- a/test/utils/language/hindi_sentences_test.dart
+++ b/test/utils/language/hindi_sentences_test.dart
@@ -33,10 +33,10 @@ void main() {
         'नई टास्क बनाते समय स्वचालित सिंकिंग सक्षम करें');
     expect(hindi.settingsPageEnableSyncOnTaskCreateDescription,
         'नई टास्क बनाते समय स्वचालित सिंकिंग सक्षम करें');
-    expect(hindi.settingsPageHighlightTaskTitle,
-        'केवल 1 दिन शेष होने पर कार्य की सीमा बनाएं');
+    expect(
+        hindi.settingsPageHighlightTaskTitle, 'तत्काल कार्यों को हाइलाइट करें');
     expect(hindi.settingsPageHighlightTaskDescription,
-        'केवल 1 दिन शेष होने पर कार्य की सीमा बनाएं');
+        '1 दिन के भीतर देय या अतिदेय कार्यों को हाइलाइट करें');
     expect(hindi.settingsPageEnable24hrFormatTitle,
         '24 घंटे का प्रारूप सक्षम करें');
     expect(hindi.settingsPageEnable24hrFormatDescription,

--- a/test/utils/language/marathi_sentences_test.dart
+++ b/test/utils/language/marathi_sentences_test.dart
@@ -33,9 +33,9 @@ void main() {
     expect(marathi.settingsPageEnableSyncOnTaskCreateDescription,
         'नवीन कार्य तयार करताना स्वयंसिंकिंग सक्षम करा');
     expect(marathi.settingsPageHighlightTaskTitle,
-        'फक्त 1 दिवस शेष असताना कार्याची सीमा बनवा');
+        'तातडीच्या कार्यांना हायलाईट करा');
     expect(marathi.settingsPageHighlightTaskDescription,
-        'फक्त 1 दिवस शेष असताना कार्याची सीमा बनवा');
+        '1 दिवसाच्या आत देय किंवा मुदत संपलेल्या कार्यांना हायलाईट करा');
     expect(marathi.settingsPageEnable24hrFormatTitle,
         '24 तासाचा स्वरूप सक्षम करा');
     expect(marathi.settingsPageEnable24hrFormatDescription,

--- a/test/utils/language/spanish_sentences_test.dart
+++ b/test/utils/language/spanish_sentences_test.dart
@@ -35,10 +35,9 @@ void main() {
         'Habilitar sincronización automática al crear nuevas tareas');
     expect(spanish.settingsPageEnableSyncOnTaskCreateDescription,
         'Habilitar sincronización automática al crear nuevas tareas');
-    expect(spanish.settingsPageHighlightTaskTitle,
-        'Resaltar tareas con 1 día restante');
+    expect(spanish.settingsPageHighlightTaskTitle, 'Resaltar tareas urgentes');
     expect(spanish.settingsPageHighlightTaskDescription,
-        'Resaltar tareas con 1 día restante');
+        'Resaltar tareas que vencen en 1 día o están vencidas');
     expect(spanish.settingsPageEnable24hrFormatTitle,
         'Habilitar formato de 24 horas');
     expect(spanish.settingsPageEnable24hrFormatDescription,


### PR DESCRIPTION
# Description

- Highlight the tasks which are overdue(passed the due date) in red.
- Fixed the text detail in settings to make more sense

## Closes #475 

## Screenshots

![image](https://github.com/user-attachments/assets/d76b109d-f3e4-45c1-be47-25c54caafe66)
![image](https://github.com/user-attachments/assets/a64158e4-bdfc-4793-9b1a-1817285c8191)
![image](https://github.com/user-attachments/assets/74f50cf9-0189-4a03-b2f2-2a105362940f)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing