### PR TITLE
fix: backend url variable name made consistent

### DIFF
--- a/lib/app/utils/taskchampion/taskchampion.dart
+++ b/lib/app/utils/taskchampion/taskchampion.dart
@@ -25,14 +25,14 @@ class ManageTaskChampionCreds extends StatelessWidget {
     _encryptionSecretController.text =
         prefs.getString('encryptionSecret') ?? '';
     _clientIdController.text = prefs.getString('clientId') ?? '';
-    _ccsyncBackendUrlController.text = prefs.getString('championApiUrl') ?? '';
+    _ccsyncBackendUrlController.text = prefs.getString('ccsyncBackendUrl') ?? '';
   }
 
   Future<void> _saveCredentials(BuildContext context) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString('encryptionSecret', _encryptionSecretController.text);
     await prefs.setString('clientId', _clientIdController.text);
-    await prefs.setString('championApiUrl', _ccsyncBackendUrlController.text);
+    await prefs.setString('ccsyncBackendUrl', _ccsyncBackendUrlController.text);
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Credentials saved successfully')),
     );


### PR DESCRIPTION
Fixed simple typo for backend ccsync url variable name

# Description

Changes `ManageTaskChampionCreds` url setter (`championApiUrl`) to match `CredentialsStorage` url getter (`ccsyncBackendUrl`)

## Fixes #([455](https://github.com/CCExtractor/taskwarrior-flutter/issues/455#issuecomment-2746090471))

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing