### PR TITLE
Fix routing error due to getx implementation

### DIFF
--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -24,7 +24,7 @@ abstract class _Paths {
   _Paths._();
   static const HOME = '/home';
   static const ONBOARDING = '/onboarding';
-  static const SPLASH = '/splash';
+  static const SPLASH = '/';
   static const MANAGE_TASK_SERVER = '/manage-task-server';
   static const DETAIL_ROUTE = '/detail-route';
   static const PROFILE = '/profile';

--- a/test/routes/app_routes_test.dart
+++ b/test/routes/app_routes_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('Routes should be defined correctly', () {
     expect(Routes.HOME, '/home');
     expect(Routes.ONBOARDING, '/onboarding');
-    expect(Routes.SPLASH, '/splash');
+    expect(Routes.SPLASH, '/');
     expect(Routes.MANAGE_TASK_SERVER, '/manage-task-server');
     expect(Routes.DETAIL_ROUTE, '/detail-route');
     expect(Routes.PROFILE, '/profile');


### PR DESCRIPTION
# Description

Fixed the error that was occuring when the app was launched from android widget. It was occuring due to the issue exiting in getx inner implementation. Refer [here](https://github.com/jonataslaw/getx/issues/3040).

## Fixes #473 


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing