### PR TITLE
fix: make 'Tag' label bold in Edit Task screen

### DIFF
--- a/lib/app/modules/detailRoute/views/tags_widget.dart
+++ b/lib/app/modules/detailRoute/views/tags_widget.dart
@@ -11,6 +11,7 @@ import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 
 import 'package:taskwarrior/app/utils/constants/constants.dart';
 import 'package:taskwarrior/app/utils/constants/utilites.dart';
+import 'package:taskwarrior/app/utils/gen/fonts.gen.dart';
 import 'package:taskwarrior/app/utils/language/sentence_manager.dart';
 import 'package:taskwarrior/app/utils/taskfunctions/validate.dart';
 import 'package:taskwarrior/app/utils/themes/theme_extension.dart';
@@ -47,10 +48,27 @@ class TagsWidget extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           child: Row(
             children: [
-              Text(
-                '${'$name:'.padRight(13)}${(value as ListBuilder?)?.build()}',
-                style: TextStyle(
-                  color: textColor,
+              RichText(
+                text: TextSpan(
+                  children: <TextSpan>[
+                    TextSpan(
+                      text: '$name:'.padRight(13),
+                      style: TextStyle(
+                        fontFamily: FontFamily.poppins,
+                        fontWeight: TaskWarriorFonts.bold,
+                        fontSize: TaskWarriorFonts.fontSizeMedium,
+                        color: textColor,
+                      ),
+                    ),
+                    TextSpan(
+                      text: '${(value as ListBuilder?)?.build()}',
+                      style: TextStyle(
+                        fontFamily: FontFamily.poppins,
+                        fontSize: TaskWarriorFonts.fontSizeMedium,
+                        color: textColor,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],


### PR DESCRIPTION
# Description

This PR updates the "Tag" label styling in the Edit Task screen to use a bold font weight. Other labels in the screen already use bold text, so this change improves UI consistency and readability

## Fixes #(issue_no)

No issue was opened for this change since it is a small UI fix. 

## Screenshots

![Before](https://github.com/user-attachments/assets/d4b20013-ba52-4e72-96fa-30bb0c7c8ee6)
![After](https://github.com/user-attachments/assets/78940837-5474-490b-bd17-fc47c40d1dee)

## Checklist

- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ x ] Code follows the established coding style guidelines
- [ x ] All tests are passing