### PR TITLE
fix: 'No' button in unsaved-changes dialog does not navigate back

### DIFF
--- a/lib/app/modules/detailRoute/views/detail_route_view.dart
+++ b/lib/app/modules/detailRoute/views/detail_route_view.dart
@@ -52,6 +52,7 @@ class DetailRouteView extends GetView<DetailRouteController> {
                 ),
               ),
               actions: [
+                // YES → save and pop
                 TextButton(
                   onPressed: () {
                     // Get.back(); // Close the dialog first
@@ -73,11 +74,12 @@ class DetailRouteView extends GetView<DetailRouteController> {
                     ),
                   ),
                 ),
+
+                // NO → discard and pop
                 TextButton(
                   onPressed: () {
                     // Get.offAll(() => const HomeView());
-
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pop(false);
                   },
                   child: Text(
                     SentenceManager(
@@ -89,9 +91,11 @@ class DetailRouteView extends GetView<DetailRouteController> {
                     ),
                   ),
                 ),
+
+                // CANCEL → stay on page
                 TextButton(
                   onPressed: () {
-                    Navigator.of(context).pop(false);
+                    Navigator.of(context).pop(null);
                   },
                   child: Text(
                     SentenceManager(
@@ -107,7 +111,12 @@ class DetailRouteView extends GetView<DetailRouteController> {
             );
           },
         );
-        return save == true;
+        if (save == null) {
+          // Cancel → stay
+          return false;
+        }
+        // Yes (true) or No (false) → both allow popping the screen
+        return true;
       },
       child: Scaffold(
           backgroundColor: tColors.primaryBackgroundColor,


### PR DESCRIPTION
# Description

Fixes the behavior of the unsaved-changes dialog shown when leaving the Task Edit screen.  
Previously the **No** button closed the dialog without returning a value, which caused the `onWillPop` handler to treat it like a cancel and prevented navigation back. This change makes the **No** button return `false` from the dialog and updates `onWillPop` so that:
- `Yes` → saves then allows the route to pop,
- `No`  → discards changes and allows the route to pop,
- `Cancel` → stays on the page (no pop).

## Fixes #511 

## Screenshots

**Before (issue):**  
(see issue #511 for the before video)

**After (this PR):**  

https://github.com/user-attachments/assets/0e2943c9-176c-4b4a-ac24-531d157abcaa

Tapping "No" now discards changes and navigates back to the previous screen

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing