### PR TITLE
fix: start date not saved when editing task

### DIFF
--- a/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
+++ b/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
@@ -106,7 +106,7 @@ class DetailRouteController extends GetxController {
     statusValue.value = modify.draft.status;
     entryValue.value = modify.draft.entry;
     modifiedValue.value = modify.draft.modified;
-    startValue.value ??= null;
+    startValue.value = modify.draft.start; //start date saves
     endValue.value = modify.draft.end;
     dueValue.value = modify.draft.due;
     waitValue.value = modify.draft.wait;


### PR DESCRIPTION
# Description

This PR fixes an issue where the Start Date selected while editing a task was not being saved.
The root cause was that startValue in DetailRouteController.initValues() was always being set to null, preventing the UI from loading the existing start value and causing saves to fail silently.

This update ensures:
startValue is initialized correctly from modify.draft.start
The selected Start Date persists after saving
The Start Date appears correctly when returning to the task detail screen

No additional dependencies required.
## Fixes #515 

## Screenshots

https://github.com/user-attachments/assets/c3390222-4b8f-440d-9bc7-a5b1ed0105e0

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing