### PR TITLE
Fix: Start date remains unset unless explicitly selected by user

### DIFF
--- a/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
+++ b/lib/app/modules/detailRoute/controllers/detail_route_controller.dart
@@ -17,6 +17,9 @@ class DetailRouteController extends GetxController {
   var onEdit = false.obs;
   var isReadOnly = false.obs;
 
+  // Track whether user explicitly selected a start date
+  bool startEdited = false;
+
   @override
   void onInit() {
     super.onInit();
@@ -50,13 +53,19 @@ class DetailRouteController extends GetxController {
     }
 
     if (name == 'start') {
-      debugPrint('Start Value Changed to $newValue');
+      startEdited = true; // MARK AS USER-SELECTED
       startValue.value = newValue;
     }
     initValues();
   }
 
   Future<void> saveChanges() async {
+    // If start was never edited AND backend auto-generated it (start == entry)
+    if (!startEdited &&
+        modify.original.start != null &&
+        modify.original.start!.isAtSameMomentAs(modify.original.entry)) {
+      modify.set('start', null); // remove auto start
+    }
     var now = DateTime.now().toUtc();
     modify.save(modified: () => now);
     onEdit.value = false;
@@ -106,7 +115,20 @@ class DetailRouteController extends GetxController {
     statusValue.value = modify.draft.status;
     entryValue.value = modify.draft.entry;
     modifiedValue.value = modify.draft.modified;
-    startValue.value ??= null;
+    final originalStart = modify.original.start;
+    final originalEntry = modify.original.entry;
+
+    final backendAutoStart = (originalStart != null &&
+        originalStart.isAtSameMomentAs(originalEntry));
+
+    // START DATE LOGIC (THE FIX)
+    if (startEdited) {
+      startValue.value = modify.draft.start;
+    } else if (backendAutoStart) {
+      startValue.value = null; // Do not show backend auto start
+    } else {
+      startValue.value = modify.draft.start; // Existing meaningful start
+    }
     endValue.value = modify.draft.end;
     dueValue.value = modify.draft.due;
     waitValue.value = modify.draft.wait;
@@ -148,15 +170,7 @@ class DetailRouteController extends GetxController {
       const Duration(milliseconds: 500),
       () {
         SaveTourStatus.getDetailsTourStatus().then((value) => {
-              if (value == false)
-                {
-                  tutorialCoachMark.show(context: context),
-                }
-              else
-                {
-                  // ignore: avoid_print
-                  print('User has seen this page'),
-                }
+              if (!value) {tutorialCoachMark.show(context: context)}
             });
       },
     );

--- a/lib/app/utils/taskfunctions/draft.dart
+++ b/lib/app/utils/taskfunctions/draft.dart
@@ -1,4 +1,3 @@
-
 import 'package:taskwarrior/app/models/models.dart';
 import 'package:taskwarrior/app/utils/taskfunctions/patch.dart';
 

--- a/lib/app/utils/taskfunctions/modify.dart
+++ b/lib/app/utils/taskfunctions/modify.dart
@@ -22,6 +22,7 @@ class Modify {
 
   Task get draft => _draft.draft;
   int get id => _draft.original.id!;
+  Task get original => _draft.original;
 
   Map<dynamic, Map> get changes {
     var result = <dynamic, Map>{};


### PR DESCRIPTION
# Description

Prevent backend/auto-generated start from appearing for new tasks. Start now:
- remains null by default for new tasks,
- is set only when the user explicitly selects it in Edit,
- persists correctly after saving and reopening.

## Fixes #515

## Screenshots

https://github.com/user-attachments/assets/ae3dd3dc-9b67-4798-bf4f-0126ac35cefe

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing