### PR TITLE
feat(home): add search focus management in HomePage

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -61,6 +61,7 @@ class HomeController extends GetxController {
   final RxBool sortHeaderVisible = false.obs;
   final RxBool searchVisible = false.obs;
   final TextEditingController searchController = TextEditingController();
+  final FocusNode searchFocusNode = FocusNode();
   final StringTagController stringTagController = StringTagController();
   late RxBool serverCertExists;
   final Rx<SupportedLanguage> selectedLanguage = SupportedLanguage.english.obs;
@@ -481,6 +482,12 @@ class HomeController extends GetxController {
     if (!searchVisible.value) {
       searchedTasks.assignAll(queriedTasks);
       searchController.text = '';
+      searchFocusNode.unfocus(); // Unfocus when hiding
+    } else {
+      // Request focus after the frame is built to ensure widget exists in tree
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        searchFocusNode.requestFocus();
+      });
     }
   }
 
@@ -827,4 +834,11 @@ class HomeController extends GetxController {
   //           forReplica: taskReplica.value));
   //   Get.dialog(showDialog);
   // }
+
+  @override
+  void onClose() {
+    searchFocusNode.dispose();
+    searchController.dispose();
+    super.onClose();
+  }
 }

--- a/lib/app/modules/home/views/home_page_body.dart
+++ b/lib/app/modules/home/views/home_page_body.dart
@@ -37,6 +37,7 @@ class HomePageBody extends StatelessWidget {
                     margin: const EdgeInsets.symmetric(
                         horizontal: 10, vertical: 10),
                     child: SearchBar(
+                      focusNode: controller.searchFocusNode,
                       backgroundColor: WidgetStateProperty.all<Color>(
                           (tColors.primaryBackgroundColor!)),
                       surfaceTintColor: WidgetStateProperty.all<Color>(


### PR DESCRIPTION
# Description

Ensures the SearchBar automatically receives focus when it becomes visible, allowing the soft keyboard to open without requiring an additional tap. This improves the search UX by explicitly managing focus when toggling the search state.

## Fixes #536 

## Screenshots

<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/b6c089fc-3a90-4775-b7fa-9007f5c054ed" />

<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/e3cd42be-0bf5-4746-bb69-a6aea743f296" />

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing