### PR TITLE
docs: updating the link to server setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 # Getting Started
 
-In order to use the mobile app, you would need the flood backend running on your local machine. There are several ways
-you can do that and all these approaches can be found at [Taskwarrior-Flutter](https://github.com/CCExtractor/taskwarrior-flutter/wiki)
+You can setup taskserver to sync your tasks across clients.
+You can find the steps to setup one [here](https://github.com/CCExtractor/taskwarrior-flutter?tab=readme-ov-file#taskserver-setup)
 
 
 ## Steps


### PR DESCRIPTION
# Description

The link in `CONTRIBUTING.md` to setup server is pointing to the wikis of the repo but there doesnot exist any wiki page related to the server setup. Updating it to point to the server setup options in readme untill the wikis are updated.
## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing