### PR TITLE
feat: add success snackbar message for task update

### DIFF
--- a/lib/app/modules/detailRoute/views/detail_route_view.dart
+++ b/lib/app/modules/detailRoute/views/detail_route_view.dart
@@ -28,12 +28,12 @@ class DetailRouteView extends GetView<DetailRouteController> {
     return WillPopScope(
       onWillPop: () async {
         if (!controller.onEdit.value) {
-          debugPrint(
-              'DetailRouteView: No edits made, navigating back without prompt.');
+          // debugPrint(
+          // 'DetailRouteView: No edits made, navigating back without prompt.');
           // Get.offAll(() => const HomeView());
-          Navigator.of(context).pop();
+          // Navigator.of(context).pop();
           // Get.toNamed(Routes.HOME);
-          return false;
+          return true;
         }
         debugPrint(
             'DetailRouteView: Unsaved edits detected, prompting user for action.');
@@ -54,16 +54,15 @@ class DetailRouteView extends GetView<DetailRouteController> {
               actions: [
                 // YES → save and pop
                 TextButton(
-                  onPressed: () {
-                    // Get.back(); // Close the dialog first
-                    // // Wait for dialog to fully close before showing snackbar
-                    // Future.delayed(const Duration(milliseconds: 100), () {
-                    //   controller.saveChanges();
-                    // });
+                  onPressed: () =>
+                      // Get.back(); // Close the dialog first
+                      // // Wait for dialog to fully close before showing snackbar
+                      // Future.delayed(const Duration(milliseconds: 100), () {
+                      //   controller.saveChanges();
+                      // });
 
-                    controller.saveChanges();
-                    Navigator.of(context).pop(true);
-                  },
+                      // controller.saveChanges();
+                      Navigator.pop(context, true),
                   child: Text(
                     SentenceManager(
                             currentLanguage: AppSettings.selectedLanguage)
@@ -77,10 +76,9 @@ class DetailRouteView extends GetView<DetailRouteController> {
 
                 // NO → discard and pop
                 TextButton(
-                  onPressed: () {
-                    // Get.offAll(() => const HomeView());
-                    Navigator.of(context).pop(false);
-                  },
+                  onPressed: () =>
+                      // Get.offAll(() => const HomeView());
+                      Navigator.pop(context, false),
                   child: Text(
                     SentenceManager(
                             currentLanguage: AppSettings.selectedLanguage)
@@ -94,9 +92,7 @@ class DetailRouteView extends GetView<DetailRouteController> {
 
                 // CANCEL → stay on page
                 TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop(null);
-                  },
+                  onPressed: () => Navigator.pop(context, null),
                   child: Text(
                     SentenceManager(
                             currentLanguage: AppSettings.selectedLanguage)
@@ -114,6 +110,27 @@ class DetailRouteView extends GetView<DetailRouteController> {
         if (save == null) {
           // Cancel → stay
           return false;
+        }
+        if (save == true) {
+          controller.saveChanges();
+          controller.onEdit.value = false;
+
+          Future.microtask(() {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                backgroundColor: tColors.secondaryBackgroundColor,
+                content: Text(
+                   SentenceManager(
+                    currentLanguage: 
+                    AppSettings.selectedLanguage,
+                   ).sentences
+                    .taskUpdatedSuccessfully,
+                    style: TextStyle(
+                      color: tColors.primaryTextColor,
+                    )),
+              ),
+            );
+          });
         }
         // Yes (true) or No (false) → both allow popping the screen
         return true;

--- a/lib/app/utils/language/bengali_sentences.dart
+++ b/lib/app/utils/language/bengali_sentences.dart
@@ -383,7 +383,9 @@ class BengaliSentences extends Sentences {
   String get oldChanges => 'পুরানো';
   @override
   String get newChanges => 'নতুন';
-
+  @override
+  String get taskUpdatedSuccessfully => 'কাজটি সফলভাবে আপডেট হয়েছে';
+  
   @override
   String get tags => 'ট্যাগ';
   @override

--- a/lib/app/utils/language/english_sentences.dart
+++ b/lib/app/utils/language/english_sentences.dart
@@ -368,6 +368,9 @@ class EnglishSentences extends Sentences {
   @override
   String get no => 'No';
   @override
+  String get taskUpdatedSuccessfully => 'Task updated Successfully';
+  
+  @override
   String get reviewChanges => 'Review Changes';
   @override
   String get oldChanges => 'Old';

--- a/lib/app/utils/language/french_sentences.dart
+++ b/lib/app/utils/language/french_sentences.dart
@@ -385,7 +385,9 @@ class FrenchSentences extends Sentences {
   String get oldChanges => 'Ancien';
   @override
   String get newChanges => 'Nouveau';
-
+  @override 
+  String get taskUpdatedSuccessfully => 'La tâche a été mise à jour avec succès';
+  
   @override
   String get tags => 'Tags';
   @override

--- a/lib/app/utils/language/hindi_sentences.dart
+++ b/lib/app/utils/language/hindi_sentences.dart
@@ -378,6 +378,8 @@ class HindiSentences extends Sentences {
   String get oldChanges => 'पुराना';
   @override
   String get newChanges => 'नया';
+  @override
+  String get taskUpdatedSuccessfully => 'कार्य सफलतापूर्वक अपडेट हो गया है';
 
   @override
   String get tags => 'टैग';

--- a/lib/app/utils/language/marathi_sentences.dart
+++ b/lib/app/utils/language/marathi_sentences.dart
@@ -383,7 +383,9 @@ class MarathiSentences extends Sentences {
   String get oldChanges => 'जुने';
   @override
   String get newChanges => 'नवीन';
-
+  @override
+  String get taskUpdatedSuccessfully => 'कार्य यशस्वीपणे अद्ययावत झाले आहे';
+  
   @override
   String get tags => 'टॅग्स';
   @override

--- a/lib/app/utils/language/sentences.dart
+++ b/lib/app/utils/language/sentences.dart
@@ -189,6 +189,7 @@ abstract class Sentences {
   String get saveChangesConfirmation;
   String get yes;
   String get no;
+  String get taskUpdatedSuccessfully;
   String get reviewChanges;
   String get oldChanges;
   String get newChanges;

--- a/lib/app/utils/language/spanish_sentences.dart
+++ b/lib/app/utils/language/spanish_sentences.dart
@@ -383,7 +383,9 @@ class SpanishSentences extends Sentences {
   String get oldChanges => 'Antiguo';
   @override
   String get newChanges => 'Nuevo';
-
+  @override
+  String get taskUpdatedSuccessfully => 'La tarea se actualizó correctamente';
+  
   @override
   String get tags => 'Etiquetas';
   @override

--- a/test/utils/language/bengali_sentences_test.dart
+++ b/test/utils/language/bengali_sentences_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(bengali.homePageDue, 'জরুরি');
     expect(bengali.homePageTaskWarriorNotConfigured,
         'TaskServer কনফিগার করা হয়নি');
+    expect(bengali.taskUpdatedSuccessfully, 'কাজটি সফলভাবে আপডেট হয়েছে');
     expect(bengali.homePageSetup, 'সেটআপ');
     expect(bengali.homePageFilter, 'ফিল্টার');
     expect(bengali.homePageMenu, 'মেনু');

--- a/test/utils/language/english_sentences_test.dart
+++ b/test/utils/language/english_sentences_test.dart
@@ -11,6 +11,8 @@ void main() {
     expect(english.homePageDue, 'Due');
     expect(english.homePageTaskWarriorNotConfigured,
         'TaskServer is not configured');
+    expect(english.taskUpdatedSuccessfully,
+        'TaskServer is not configured');
     expect(english.homePageSetup, 'Setup');
     expect(english.homePageFilter, 'Filter');
     expect(english.homePageMenu, 'Menu');

--- a/test/utils/language/french_sentences_test.dart
+++ b/test/utils/language/french_sentences_test.dart
@@ -10,6 +10,7 @@ void main() {
     expect(french.homePageLastModified, 'Dernière modification');
     expect(french.homePageDue, 'Échéance');
     expect(french.homePageTaskWarriorNotConfigured, 'TaskServer non configuré');
+    expect(french.taskUpdatedSuccessfully, 'La tâche a été mise à jour avec succès');
     expect(french.homePageSetup, 'Configuration');
     expect(french.homePageFilter, 'Filtre');
     expect(french.homePageMenu, 'Menu');

--- a/test/utils/language/hindi_sentences_test.dart
+++ b/test/utils/language/hindi_sentences_test.dart
@@ -11,6 +11,8 @@ void main() {
     expect(hindi.homePageDue, 'देय');
     expect(
         hindi.homePageTaskWarriorNotConfigured, 'TaskServer कॉन्फ़िगर नहीं है');
+    expect(
+        hindi.taskUpdatedSuccessfully, 'कार्य सफलतापूर्वक अपडेट हो गया है');
     expect(hindi.homePageSetup, 'सेटअप');
     expect(hindi.homePageFilter, 'फ़िल्टर');
     expect(hindi.homePageMenu, 'मेन्यू');

--- a/test/utils/language/marathi_sentences_test.dart
+++ b/test/utils/language/marathi_sentences_test.dart
@@ -10,6 +10,7 @@ void main() {
     expect(marathi.homePageLastModified, 'शेवटचा बदल');
     expect(marathi.homePageDue, 'द्यावे');
     expect(marathi.homePageTaskWarriorNotConfigured, 'TaskServer संरचीत नाही');
+    expect(marathi.taskUpdatedSuccessfully, 'कार्य यशस्वीपणे अद्ययावत झाले आहे');
     expect(marathi.homePageSetup, 'सेटअप');
     expect(marathi.homePageFilter, 'फिल्टर');
     expect(marathi.homePageMenu, 'मेनू');

--- a/test/utils/language/sentences_test.dart
+++ b/test/utils/language/sentences_test.dart
@@ -24,6 +24,7 @@ void main() {
         expect(sentences.homePageLastModified, isA<String>());
         expect(sentences.homePageDue, isA<String>());
         expect(sentences.homePageTaskWarriorNotConfigured, isA<String>());
+        expect(sentences.taskUpdatedSuccessfully, isA<String>());
         expect(sentences.homePageSetup, isA<String>());
         expect(sentences.homePageFilter, isA<String>());
         expect(sentences.homePageMenu, isA<String>());

--- a/test/utils/language/spanish_sentences_test.dart
+++ b/test/utils/language/spanish_sentences_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(spanish.homePageDue, 'Vencimiento');
     expect(
         spanish.homePageTaskWarriorNotConfigured, 'TaskServer no configurado');
+    expect(spanish.taskUpdatedSuccessfully, 'La tarea se actualizó correctamente');
     expect(spanish.homePageSetup, 'Configuración');
     expect(spanish.homePageFilter, 'Filtro');
     expect(spanish.homePageMenu, 'Menú');


### PR DESCRIPTION
# Description

This PR the solve the #471 this issue. its already fixes after click of "Yes" or "No" its go back and after click on "Cancel" it stay on the detail page. i works on this part update the values and show snackbar when "Yes" is clicked.

## Fixes (#471)
## Screenshots

![stask](https://github.com/user-attachments/assets/3a76207a-ba52-4d22-966d-dfd441939a2e)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing