### PR TITLE
removed ccsync

### DIFF
--- a/lib/app/modules/profile/views/profile_view.dart
+++ b/lib/app/modules/profile/views/profile_view.dart
@@ -264,16 +264,17 @@ class ProfileView extends GetView<ProfileController> {
                                 });
                               },
                             ),
-                            RadioListTile<String>(
-                              title: const Text('CCSync (v3)'),
-                              value: 'TW3',
-                              groupValue: selectedMode,
-                              onChanged: (String? value) {
-                                setState(() {
-                                  selectedMode = value;
-                                });
-                              },
-                            ),
+                            // CCSync v3 is deprecated, so hiding it for now
+                            // RadioListTile<String>(
+                            //   title: const Text('CCSync (v3)'),
+                            //   value: 'TW3',
+                            //   groupValue: selectedMode,
+                            //   onChanged: (String? value) {
+                            //     setState(() {
+                            //       selectedMode = value;
+                            //     });
+                            //   },
+                            // ),
                             RadioListTile<String>(
                               title: const Text('TaskServer'),
                               value: 'TW2',


### PR DESCRIPTION
```
                            // CCSync v3 is deprecated, so hiding it for now
                            // RadioListTile<String>(
                            //   title: const Text('CCSync (v3)'),
                            //   value: 'TW3',
                            //   groupValue: selectedMode,
                            //   onChanged: (String? value) {
                            //     setState(() {
                            //       selectedMode = value;
                            //     });
                            //   },
                            // ),
```