### PR TITLE
fix: trim and validate task name input for whitespace

### DIFF
--- a/lib/app/modules/home/views/add_task_bottom_sheet_new.dart
+++ b/lib/app/modules/home/views/add_task_bottom_sheet_new.dart
@@ -96,7 +96,7 @@ class AddTaskBottomSheet extends StatelessWidget {
                       padding: const EdgeInsets.all(padding),
                       child: TextFormField(
                         controller: homeController.namecontroller,
-                        validator: (value) => value!.isEmpty
+                        validator: (value) => value!.trim().isEmpty
                             ? SentenceManager(
                                     currentLanguage:
                                         homeController.selectedLanguage.value)
@@ -317,7 +317,7 @@ class AddTaskBottomSheet extends StatelessWidget {
     if (homeController.formKey.currentState!.validate()) {
       debugPrint("tags ${homeController.tags}");
       var task = TaskForC(
-          description: homeController.namecontroller.text,
+          description: homeController.namecontroller.text.trim(),
           status: 'pending',
           priority: homeController.priority.value,
           entry: DateTime.now().toIso8601String(),
@@ -365,7 +365,7 @@ class AddTaskBottomSheet extends StatelessWidget {
   void onSaveButtonClicked(BuildContext context) async {
     if (homeController.formKey.currentState!.validate()) {
       try {
-        var task = taskParser(homeController.namecontroller.text)
+        var task = taskParser(homeController.namecontroller.text.trim())
             .rebuild((b) =>
                 b..due = getDueDate(homeController.selectedDates)?.toUtc())
             .rebuild((p) => p..priority = homeController.priority.value)
@@ -451,7 +451,7 @@ class AddTaskBottomSheet extends StatelessWidget {
     if (homeController.formKey.currentState!.validate()) {
       try {
         await Replica.addTaskToReplica(HashMap<String, dynamic>.from({
-          "description": homeController.namecontroller.text,
+          "description": homeController.namecontroller.text.trim(),
           "due": getDueDate(homeController.selectedDates)?.toUtc(),
           "priority": homeController.priority.value,
           "project": homeController.projectcontroller.text != ""

--- a/lib/app/utils/taskfunctions/validate.dart
+++ b/lib/app/utils/taskfunctions/validate.dart
@@ -1,7 +1,7 @@
 void validateTaskDescription(String description) {
-  if (description.isEmpty) {
+  if (description.trim().isEmpty) {
     throw FormatException(
-      'Empty description will provoke a server error.',
+      'Description cannot be empty or contain only spaces.',
       description,
       0,
     );


### PR DESCRIPTION
# Description

This PR updates task name validation to prevent whitespace-only input and automatically trim leading/trailing spaces. Users now receive a clear error message if the task name is empty or contains only spaces, improving feedback and preventing silent failures. Validation and error messaging are now consistent across the app.

## Fixes #567

## Screenshots
![Screenshot_20260123_222711](https://github.com/user-attachments/assets/dcf02fbb-fa64-42d8-ac77-8784473fa2c0)
## Checklist
- [x] Code follows the established coding style guidelines
- [x] All tests are passing