### PR TITLE
feat: added autoclosing for taskserver setup snackbar

### DIFF
--- a/lib/app/modules/home/views/home_page_app_bar.dart
+++ b/lib/app/modules/home/views/home_page_app_bar.dart
@@ -64,8 +64,6 @@ class HomePageAppBar extends StatelessWidget implements PreferredSizeWidget {
       SnackBar(
         duration: const Duration(seconds: 4),
         backgroundColor: tColors.secondaryBackgroundColor,
-        behavior: SnackBarBehavior.floating,
-        dismissDirection: DismissDirection.horizontal,
         content: Text(
           message,
           style: TextStyle(


### PR DESCRIPTION
# Description

The `SnackBar` widget was created **without a `duration` parameter**. As duration is not specified, the SnackBar will remain visible until explicitly dismissed or until a new SnackBar is shown. This caused the banner to stay on screen indefinitely, creating a poor user experience.

1. Added `duration: const Duration(seconds: 4)` to the SnackBar constructor also async `Timer` to close the snackbar forcefully in 4s.
2. The user can now also swipe to cancel the snackbar


## Fixes #577 

## Screenshots

<img width="759" height="1600" alt="image" src="https://github.com/user-attachments/assets/b019dbcc-4dcb-4e51-b82f-a3d9a8edc775" />

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing