### PR TITLE
fix: made the reports page tabs swipable for better UX

### DIFF
--- a/lib/app/modules/reports/views/reports_view.dart
+++ b/lib/app/modules/reports/views/reports_view.dart
@@ -51,9 +51,6 @@ class ReportsView extends GetView<ReportsController> {
                 color: TaskWarriorColors.appBarUnSelectedIconsColorForReports),
             indicatorColor: tColors.purpleShade,
             labelColor: TaskWarriorColors.white,
-            onTap: (value) {
-              controller.selectedIndex.value = value;
-            },
             tabs: <Widget>[
               Tab(
                 key: controller.daily,
@@ -133,8 +130,8 @@ class ReportsView extends GetView<ReportsController> {
                   ),
                 ],
               )
-            : IndexedStack(
-                index: controller.selectedIndex.value,
+            : TabBarView(
+                controller: controller.tabController,
                 children: [
                   BurnDownDaily(
                     reportsController: controller,

--- a/lib/app/modules/reports/views/reports_view_replica.dart
+++ b/lib/app/modules/reports/views/reports_view_replica.dart
@@ -69,9 +69,6 @@ class ReportsHomeReplica extends StatelessWidget {
                 unselectedLabelStyle: GoogleFonts.poppins(
                   fontWeight: TaskWarriorFonts.light,
                 ),
-                onTap: (value) {
-                  reportsController.selectedIndex.value = value;
-                },
                 tabs: <Widget>[
                   Tab(
                     key: reportsController.daily,
@@ -152,15 +149,13 @@ class ReportsHomeReplica extends StatelessWidget {
                         ),
                       ],
                     )
-                  : Obx(
-                      () => IndexedStack(
-                        index: reportsController.selectedIndex.value,
-                        children: [
-                          BurnDownDailyReplica(),
-                          BurnDownWeeklyReplica(),
-                          BurnDownMonthlyReplica(),
-                        ],
-                      ),
+                  : TabBarView(
+                      controller: reportsController.tabController,
+                      children: [
+                        BurnDownDailyReplica(),
+                        BurnDownWeeklyReplica(),
+                        BurnDownMonthlyReplica(),
+                      ],
                     ),
         );
       },

--- a/lib/app/modules/reports/views/reports_view_taskc.dart
+++ b/lib/app/modules/reports/views/reports_view_taskc.dart
@@ -65,9 +65,6 @@ class ReportsHomeTaskc extends StatelessWidget {
                 unselectedLabelStyle: GoogleFonts.poppins(
                   fontWeight: TaskWarriorFonts.light,
                 ),
-                onTap: (value) {
-                  reportsController.selectedIndex.value = value;
-                },
                 tabs: <Widget>[
                   Tab(
                     key: reportsController.daily,
@@ -148,15 +145,13 @@ class ReportsHomeTaskc extends StatelessWidget {
                         ),
                       ],
                     )
-                  : Obx(
-                      () => IndexedStack(
-                        index: reportsController.selectedIndex.value,
-                        children: [
-                          BurnDownDailyTaskc(),
-                          BurnDownWeeklyTask(),
-                          BurnDownMonthlyTaskc(),
-                        ],
-                      ),
+                  : TabBarView(
+                      controller: reportsController.tabController,
+                      children: [
+                        BurnDownDailyTaskc(),
+                        BurnDownWeeklyTask(),
+                        BurnDownMonthlyTaskc(),
+                      ],
                     ),
         );
       },


### PR DESCRIPTION
# Description

Made the `reports` page swipable by implementing `TabBarView` in `lib\app\modules\reports\views\reports_view.dart`, `lib\app\modules\reports\views\reports_view_taskc.dart` and `lib\app\modules\reports\views\reports_view_replica.dart`

From all 3 pages removed:
```dart
            onTap: (value) {
              controller.selectedIndex.value = value;
            },
```

and updated:
```dart
            IndexedStack(
                index: controller.selectedIndex.value,
```
to:
```dart
            TabBarView(
                controller: controller.tabController,
```

## Fixes #578 

## Screenshots


https://github.com/user-attachments/assets/856d7ac8-7813-4b1c-af3a-c25e7434f821



## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing