### PR TITLE
fix: improve due date display format in add task screen

### DIFF
--- a/lib/app/utils/taskfunctions/add_task_dialog_utils.dart
+++ b/lib/app/utils/taskfunctions/add_task_dialog_utils.dart
@@ -3,7 +3,26 @@ import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 import 'package:taskwarrior/app/utils/language/sentence_manager.dart';
 
 String dateToStringForAddTask(DateTime dt) {
-  return 'On ${DateFormat('yyyy-MM-dd').format(dt)} at ${DateFormat('hh:mm:ss').format(dt)}';
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final tomorrow = today.add(const Duration(days: 1));
+  final dtDate = DateTime(dt.year, dt.month, dt.day);
+
+  // Format time in 12-hour format with AM/PM
+  final timeFormat = DateFormat('h:mm a');
+  final timeString = timeFormat.format(dt);
+
+  // Check if date is today or tomorrow
+  if (dtDate == today) {
+    return 'Today • $timeString';
+  } else if (dtDate == tomorrow) {
+    return 'Tomorrow • $timeString';
+  } else {
+    // Format: "Feb 28 • 7:50 AM"
+    final dateFormat = DateFormat('MMM d');
+    final dateString = dateFormat.format(dt);
+    return '$dateString • $timeString';
+  }
 }
 
 String getPriorityText(String priority) {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Fixes #584
## Improve Due Date Display Format in Add Task Screen

### Problem
The previous date format was technical and hard to read: `On 2026-02-28 at 07:50:00`

### Solution
Updated `dateToStringForAddTask()` function to use more natural, human-readable formats:
- `Today • 7:50 AM`
- `Tomorrow • 2:30 PM`
- `Feb 28 • 11:59 PM`

### Changes
- **File:** `lib/app/utils/taskfunctions/add_task_dialog_utils.dart`
- Detect today/tomorrow and display relative dates
- Changed time format from 24-hour to 12-hour with AM/PM
- Uses `intl` package for localization support

### Benefits
- More intuitive and scannable
- Professional, modern mobile UI
- Better user experience
- Localization-ready
- No breaking changes
![WhatsApp Image 2026-02-06 at 20 40 02](https://github.com/user-attachments/assets/a6a2b0e0-cd2a-4a59-85dd-425c28933fd7)
![WhatsApp Image 2026-02-06 at 20 40 34](https://github.com/user-attachments/assets/e86297c4-e138-46c2-a167-c0a37b5ca7d6)
