### PR TITLE
Fix project filtering for tasks without a project name

### DIFF
--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -41,6 +41,7 @@ import 'package:taskwarrior/app/utils/themes/theme_extension.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
 class HomeController extends GetxController {
+  static const String noProjectValue = " (No Project) ";
   final SplashController splashController = Get.find<SplashController>();
   late Storage storage;
   final RxBool pendingFilter = false.obs;
@@ -262,6 +263,9 @@ class HomeController extends GetxController {
 
     if (projectFilter.value.isNotEmpty) {
       queriedTasks.value = queriedTasks.where((task) {
+        if (projectFilter.value == noProjectValue) {
+          return task.project == null || task.project!.isEmpty;
+        }
         if (task.project == null) {
           return false;
         } else {

--- a/lib/app/modules/home/views/project_column_home_page.dart
+++ b/lib/app/modules/home/views/project_column_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import 'package:taskwarrior/app/modules/home/controllers/home_controller.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 import 'package:taskwarrior/app/utils/constants/taskwarrior_fonts.dart';
@@ -63,24 +64,58 @@ class ProjectsColumn extends StatelessWidget {
             ],
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.only(left: 10, right: 10, top: 10),
+        GestureDetector(
+          onTap: () => callback(''),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              Text(SentenceManager(
-                      currentLanguage: AppSettings.selectedLanguage).sentences.allProjects,
-                  style: TextStyle(
-                    fontFamily: FontFamily.poppins,
-                    fontSize: TaskWarriorFonts.fontSizeSmall,
-                    color: tColors.primaryTextColor,
-                  )),
+              Radio(
+                activeColor: tColors.primaryTextColor,
+                focusColor: tColors.secondaryTextColor,
+                toggleable: true,
+                value: '',
+                groupValue: projectFilter,
+                onChanged: (_) => callback(''),
+              ),
+              Text(
+                SentenceManager(currentLanguage: AppSettings.selectedLanguage)
+                    .sentences
+                    .allProjects,
+                style: GoogleFonts.poppins(
+                  color: tColors.primaryTextColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+        GestureDetector(
+          onTap: () => callback(HomeController.noProjectValue),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Radio(
+                activeColor: tColors.primaryTextColor,
+                focusColor: tColors.secondaryTextColor,
+                toggleable: true,
+                value: HomeController.noProjectValue,
+                groupValue: projectFilter,
+                onChanged: (_) => callback(HomeController.noProjectValue),
+              ),
+              Text(
+                SentenceManager(currentLanguage: AppSettings.selectedLanguage)
+                    .sentences
+                    .noProject,
+                style: GoogleFonts.poppins(
+                  color: tColors.primaryTextColor,
+                ),
+              ),
             ],
           ),
         ),
         if (projects.isNotEmpty)
           ...projects.entries
-              .where((entry) => entry.value.parent == null)
+              .where((entry) =>
+                  entry.value.parent == null && entry.key.isNotEmpty)
               .map((entry) => ProjectTile(
                     project: entry.key,
                     projects: projects,

--- a/lib/app/modules/home/views/project_column_taskc.dart
+++ b/lib/app/modules/home/views/project_column_taskc.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:taskwarrior/app/modules/home/controllers/home_controller.dart';
 import 'package:taskwarrior/app/utils/app_settings/app_settings.dart';
 import 'package:taskwarrior/app/utils/constants/taskwarrior_fonts.dart';
 import 'package:taskwarrior/app/utils/gen/fonts.gen.dart';
@@ -65,17 +66,27 @@ class ProjectColumnTaskc extends StatelessWidget {
           ),
         ),
         ProjectTileTaskc(
-            project: SentenceManager(
-              currentLanguage: AppSettings.selectedLanguage,
-            ).sentences.allProjects,
+            project: '',
             projectFilter: projectFilter,
-            callback: callback),
+            callback: callback,
+            displayName: SentenceManager(
+              currentLanguage: AppSettings.selectedLanguage,
+            ).sentences.allProjects),
+        ProjectTileTaskc(
+            project: HomeController.noProjectValue,
+            projectFilter: projectFilter,
+            callback: (val) => callback(val),
+            displayName: SentenceManager(
+              currentLanguage: AppSettings.selectedLanguage,
+            ).sentences.noProject),
         if (projects.isNotEmpty)
-          ...projects.map((entry) => ProjectTileTaskc(
-                project: entry,
-                projectFilter: projectFilter,
-                callback: callback,
-              ))
+          ...projects
+              .where((entry) => entry.isNotEmpty)
+              .map((entry) => ProjectTileTaskc(
+                    project: entry,
+                    projectFilter: projectFilter,
+                    callback: callback,
+                  ))
         else
           Column(
             children: [
@@ -105,11 +116,13 @@ class ProjectTileTaskc extends StatelessWidget {
     required this.project,
     required this.projectFilter,
     required this.callback,
+    this.displayName,
   });
 
   final String project;
   final String projectFilter;
   final void Function(String) callback;
+  final String? displayName;
 
   @override
   Widget build(BuildContext context) {
@@ -126,7 +139,7 @@ class ProjectTileTaskc extends StatelessWidget {
             onChanged: (_) => callback(project),
           ),
           Text(
-            project,
+            displayName ?? project,
             style: TextStyle(
               color: tColors.primaryTextColor,
             ),

--- a/lib/app/utils/language/bengali_sentences.dart
+++ b/lib/app/utils/language/bengali_sentences.dart
@@ -411,6 +411,8 @@ class BengaliSentences extends Sentences {
   @override
   String get noProjectsFound => 'কোনো প্রকল্প পাওয়া যায়নি';
   @override
+  String get noProject => 'কোন প্রকল্প নেই';
+  @override
   String get project => 'প্রকল্প';
 
   @override

--- a/lib/app/utils/language/english_sentences.dart
+++ b/lib/app/utils/language/english_sentences.dart
@@ -401,6 +401,8 @@ class EnglishSentences extends Sentences {
   @override
   String get noProjectsFound => 'No Projects Found';
   @override
+  String get noProject => 'No Project';
+  @override
   String get project => 'Project';
 
   @override

--- a/lib/app/utils/language/french_sentences.dart
+++ b/lib/app/utils/language/french_sentences.dart
@@ -414,6 +414,8 @@ class FrenchSentences extends Sentences {
   @override
   String get noProjectsFound => 'Aucun projet trouvé';
   @override
+  String get noProject => 'Aucun Projet';
+  @override
   String get project => 'Projet';
 
   @override

--- a/lib/app/utils/language/german_sentences.dart
+++ b/lib/app/utils/language/german_sentences.dart
@@ -401,6 +401,8 @@ class GermanSentences extends Sentences {
   @override
   String get noProjectsFound => 'Keine Projekte gefunden';
   @override
+  String get noProject => 'Kein Projekt';
+  @override
   String get project => 'Projekt';
 
   @override

--- a/lib/app/utils/language/hindi_sentences.dart
+++ b/lib/app/utils/language/hindi_sentences.dart
@@ -406,6 +406,8 @@ class HindiSentences extends Sentences {
   @override
   String get noProjectsFound => 'कोई परियोजना नहीं मिली';
   @override
+  String get noProject => 'कोई प्रोजेक्ट नहीं';
+  @override
   String get project => 'परियोजना';
 
   @override

--- a/lib/app/utils/language/marathi_sentences.dart
+++ b/lib/app/utils/language/marathi_sentences.dart
@@ -412,6 +412,8 @@ class MarathiSentences extends Sentences {
   @override
   String get noProjectsFound => 'प्रकल्प सापडले नाहीत';
   @override
+  String get noProject => 'कोणताही प्रकल्प नाही';
+  @override
   String get project => 'प्रकल्प';
 
   @override

--- a/lib/app/utils/language/sentences.dart
+++ b/lib/app/utils/language/sentences.dart
@@ -210,6 +210,7 @@ abstract class Sentences {
 
   String get allProjects;
   String get noProjectsFound;
+  String get noProject;
   String get project;
 
   String get select;

--- a/lib/app/utils/language/spanish_sentences.dart
+++ b/lib/app/utils/language/spanish_sentences.dart
@@ -412,6 +412,8 @@ class SpanishSentences extends Sentences {
   @override
   String get noProjectsFound => 'No se encontraron proyectos';
   @override
+  String get noProject => 'Sin Proyecto';
+  @override
   String get project => 'Proyecto';
 
   @override

--- a/lib/app/utils/language/urdu_sentences.dart
+++ b/lib/app/utils/language/urdu_sentences.dart
@@ -404,6 +404,8 @@ class UrduSentences extends Sentences {
   @override
   String get noProjectsFound => 'کوئی پراجیکٹ نہیں ملا';
   @override
+  String get noProject => 'کوئی پروجیکٹ نہیں';
+  @override
   String get project => 'پراجیکٹ';
 
   @override


### PR DESCRIPTION
# Description

This PR fixes an issue where selecting "**No Project**" incorrectly displayed all tasks instead of only tasks without a project.

The root cause was that an **empty string ("") was used to represent both:**

- **All Projects** (no filter applied)

- **No Project** (tasks without a project name)

This overlap caused the filter to reset instead of isolating tasks with no assigned project.

- **Changes**

- **Logic Separation**

Introduced a sentinel constant **HomeController.noProjectValue** to explicitly represent the "No Project" filter state.

- **Filtering Logic Fix**

Updated **HomeController._refreshTasks()** to correctly filter tasks where:

- **project == null**

- **project == ""**

when the "No Project" filter is selected.

- **Localization Support**

Added noProject translation keys to the Sentences localization system for all supported languages:

- English

- Hindi

- Marathi

- French

- Spanish

- Bengali
 
- German

- Urdu


- **UI Improvements**

- Added a dedicated "**No Project**" option to project filter views.

- Fixed "**All Projects**" radio buttons to correctly clear the filter.

- Removed redundant blank entries from dynamic project lists to prevent UI clutter.

- **Result**

Selecting "**No Project**" now correctly displays only tasks without an assigned project, instead of resetting the filter and displaying all tasks.

## Fixes #610 

This PR resolves the bug reported in issue #610, where selecting the "No Project Name" filter failed to isolate tasks without projects.

## Screenshots

- **Before Fix**

![WhatsApp Image 2026-03-11 at 3 58 11 PM](https://github.com/user-attachments/assets/99cd7b88-4ed8-416a-b35f-62f7151c172c)


**Selecting "No Project" incorrectly displayed all tasks.**

- **After Fix**

![WhatsApp Image 2026-03-11 at 8 28 42 PM](https://github.com/user-attachments/assets/5fc03bab-4663-423f-9ce9-9656b88a61e4)


**Selecting "No Project" correctly shows only tasks without a project.**

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes (not required for this UI/filter logic fix)
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to filter tasks by "No Project" status, allowing users to view tasks without assigned projects
  * Enhanced project filtering interface with radio button selection for "All Projects" and "No Project" options
  * Added multilingual support for "No Project" label across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->