### PR TITLE
Improve UI consistency of directory action buttons in Settings screen

### DIFF
--- a/lib/app/modules/settings/views/settings_page_select_directory_list_tile.dart
+++ b/lib/app/modules/settings/views/settings_page_select_directory_list_tile.dart
@@ -54,15 +54,16 @@ class SettingsPageSelectDirectoryListTile extends StatelessWidget {
           ),
           IntrinsicHeight(
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Reset to Default Button
                 Expanded(
-                  child: TextButton(
-                    style: ButtonStyle(
-                      backgroundColor: WidgetStateProperty.all<Color>(
-                        tColors.secondaryBackgroundColor!,
+                  child: OutlinedButton.icon(
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(color: tColors.purpleShade!),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
                       ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
                     ),
                     onPressed: () async {
                       if (await controller.getBaseDirectory() == "Default") {
@@ -169,7 +170,8 @@ class SettingsPageSelectDirectoryListTile extends StatelessWidget {
                         );
                       }
                     },
-                    child: Text(
+                    icon: Icon(Icons.restore, color: tColors.purpleShade, size: 20),
+                    label: Text(
                       SentenceManager(
                               currentLanguage:
                                   controller.selectedLanguage.value)
@@ -178,24 +180,31 @@ class SettingsPageSelectDirectoryListTile extends StatelessWidget {
                       textAlign: TextAlign.center,
                       softWrap: true,
                       maxLines: 2,
-                      style: TextStyle(
+                      style: GoogleFonts.poppins(
                         color: tColors.purpleShade,
+                        fontSize: TaskWarriorFonts.fontSizeSmall,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
                 ),
-                const SizedBox(width: 10),
+                const SizedBox(width: 12),
 
                 // Change Directory Button
                 Expanded(
-                  child: TextButton(
-                    style: ButtonStyle(
-                      backgroundColor: WidgetStateProperty.all<Color>(
-                        tColors.secondaryBackgroundColor!,
+                  child: ElevatedButton.icon(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: tColors.purpleShade,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
                       ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      elevation: 2,
                     ),
                     onPressed: () => controller.pickDirectory(context),
-                    child: Text(
+                    icon: const Icon(Icons.folder_open, size: 20),
+                    label: Text(
                       SentenceManager(
                               currentLanguage:
                                   controller.selectedLanguage.value)
@@ -205,7 +214,11 @@ class SettingsPageSelectDirectoryListTile extends StatelessWidget {
                       softWrap: true,
                       maxLines: 2,
                       overflow: TextOverflow.visible,
-                      style: TextStyle(color: tColors.purpleShade),
+                      style: GoogleFonts.poppins(
+                        color: Colors.white,
+                        fontSize: TaskWarriorFonts.fontSizeSmall,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Description

This PR improves the UI consistency of the **"Set To Default"** and **"Change Directory"** buttons in the **Settings → Storage and Data** section.

Previously these buttons appeared visually inconsistent with the rest of the settings UI.

## Changes

* Updated button styling for better visual hierarchy
* Added outlined style for **Set To Default**
* Used filled primary style for **Change Directory**
* Improved alignment and spacing between the buttons

## Screenshots

### Before

<img width="717" height="1600" alt="image" src="https://github.com/user-attachments/assets/b27b2a0a-f3e5-4e5c-868d-9a15d6488ad6" />


### After

<img width="717" height="1600" alt="image" src="https://github.com/user-attachments/assets/7efb2882-6606-4a25-8e26-203fe5ec132b" />


## Type of Change

UI improvement / UX consistency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated directory selection buttons with icons and purple accent styling, including rounded corners and improved visual hierarchy
  * Enhanced typography with refined font styling and sizing throughout the settings interface
  * Improved button spacing and layout consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->