### PR TITLE
fix: Drawer pop() after item is selected

### DIFF
--- a/lib/app/modules/home/views/nav_drawer.dart
+++ b/lib/app/modules/home/views/nav_drawer.dart
@@ -86,6 +86,7 @@ class NavDrawer extends StatelessWidget {
                   currentLanguage: homeController.selectedLanguage.value,
                 ).sentences.navDrawerProfile,
                 onTap: () {
+                  Navigator.of(context).pop();
                   Get.toNamed(Routes.PROFILE);
                 },
               ),
@@ -100,6 +101,7 @@ class NavDrawer extends StatelessWidget {
                     currentLanguage: homeController.selectedLanguage.value,
                   ).sentences.navDrawerReports,
                   onTap: () {
+                    Navigator.of(context).pop();
                     Get.toNamed(Routes.REPORTS);
                   },
                 ),
@@ -115,6 +117,7 @@ class NavDrawer extends StatelessWidget {
                     currentLanguage: homeController.selectedLanguage.value,
                   ).sentences.navDrawerReports,
                   onTap: () {
+                    Navigator.of(context).pop();
                     Get.to(() => ReportsHomeTaskc());
                   },
                 ),
@@ -130,6 +133,7 @@ class NavDrawer extends StatelessWidget {
                     currentLanguage: homeController.selectedLanguage.value,
                   ).sentences.navDrawerReports,
                   onTap: () {
+                    Navigator.of(context).pop();
                     Get.to(() => ReportsHomeReplica());
                   },
                 ),
@@ -142,6 +146,7 @@ class NavDrawer extends StatelessWidget {
                   currentLanguage: homeController.selectedLanguage.value,
                 ).sentences.navDrawerAbout,
                 onTap: () {
+                  Navigator.of(context).pop();
                   Get.toNamed(Routes.ABOUT);
                 },
               ),
@@ -153,6 +158,7 @@ class NavDrawer extends StatelessWidget {
                   currentLanguage: homeController.selectedLanguage.value,
                 ).sentences.navDrawerSettings,
                 onTap: () async {
+                  Navigator.of(context).pop();
                   final SharedPreferences prefs =
                       await SharedPreferences.getInstance();
                   homeController.syncOnStart.value =


### PR DESCRIPTION
# Description

**Fix navigation drawer not closing on selection**

Added `Navigator.pop` to the drawer menu items (Profile, Reports, Settings). Previously, the drawer stayed open in the background when navigating to other screens, which made the UI look glitchy when pressing back.


## Fixes 

Fixes: #628 

## Screenshots

### Before
https://github.com/user-attachments/assets/f9661742-3988-4e98-8012-94c48c92db8e

### After
https://github.com/user-attachments/assets/54e958ba-f8a7-4f8a-9398-2b8d84fce0c1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Navigation drawer now automatically closes when users navigate to Profile, Reports, About, and Settings sections. This ensures a smoother navigation experience by dismissing the drawer before the destination screen loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->