### PR TITLE
fix: aligns storage and data tile under settings to left. Fixes #639

### DIFF
--- a/lib/app/modules/settings/views/settings_page_select_directory_list_tile.dart
+++ b/lib/app/modules/settings/views/settings_page_select_directory_list_tile.dart
@@ -39,6 +39,7 @@ class SettingsPageSelectDirectoryListTile extends StatelessWidget {
         ),
       ),
       subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Obx(
             () => Text(


### PR DESCRIPTION
# Description

fixed alignment of Storage and Data tile under settings

## Fixes

Fixes: #639 

## Screenshots

|Before | After | 
|--|--|
|  ![IMAGE 2026-03-27 00:27:15](https://github.com/user-attachments/assets/f2bbca86-540c-4fc2-b104-fc019f2355ac)  |  ![IMAGE 2026-03-27 00:27:20](https://github.com/user-attachments/assets/de63a32f-2748-49d0-aedd-b0e967ee6762) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subtitle text alignment in settings list items to display with proper left alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->